### PR TITLE
fix: accessing models as member of organization

### DIFF
--- a/apps/main/src/models/presentation/models.controller.ts
+++ b/apps/main/src/models/presentation/models.controller.ts
@@ -84,7 +84,7 @@ export class ModelsController {
       user: {
         id: (req.authContext.user as User).id,
       },
-    }, PermissionAction.UPDATE, organization.toPermissionSubject())) {
+    }, PermissionAction.READ, organization.toPermissionSubject())) {
       throw new ForbiddenException();
     }
 
@@ -152,7 +152,7 @@ export class ModelsController {
       user: {
         id: (req.authContext.user as User).id,
       },
-    }, PermissionAction.UPDATE, organization.toPermissionSubject())) {
+    }, PermissionAction.READ, organization.toPermissionSubject())) {
       throw new ForbiddenException();
     }
     return (await this.modelsService.findAllByOrganization(organizationId)).map(
@@ -180,7 +180,7 @@ export class ModelsController {
       user: {
         id: (req.authContext.user as User).id,
       },
-    }, PermissionAction.UPDATE, organization.toPermissionSubject())) {
+    }, PermissionAction.READ, organization.toPermissionSubject())) {
       throw new ForbiddenException();
     }
     const model = await this.modelsService.findOneOrFail(id);
@@ -215,7 +215,7 @@ export class ModelsController {
       user: {
         id: (req.authContext.user as User).id,
       },
-    }, PermissionAction.UPDATE, organization.toPermissionSubject())) {
+    }, PermissionAction.READ, organization.toPermissionSubject())) {
       throw new ForbiddenException();
     }
     const model = await this.modelsService.findOneOrFail(modelId);
@@ -257,7 +257,7 @@ export class ModelsController {
       user: {
         id: (req.authContext.user as User).id,
       },
-    }, PermissionAction.UPDATE, organization.toPermissionSubject())) {
+    }, PermissionAction.READ, organization.toPermissionSubject())) {
       throw new ForbiddenException();
     }
     const model = await this.modelsService.findOneOrFail(modelId);
@@ -303,7 +303,7 @@ export class ModelsController {
       user: {
         id: (req.authContext.user as User).id,
       },
-    }, PermissionAction.UPDATE, organization.toPermissionSubject())) {
+    }, PermissionAction.READ, organization.toPermissionSubject())) {
       throw new ForbiddenException();
     }
     const model = await this.modelsService.findOneOrFail(modelId);


### PR DESCRIPTION
This pull request updates the permission checks in the `ModelsController` to require "read" access instead of "update" access for several endpoints. This change ensures that users only need read-level permissions to access model and organization data, making the API more permissive for data retrieval operations.

Authorization changes:

* Changed permission checks from `PermissionAction.UPDATE` to `PermissionAction.READ` in six controller methods, allowing users with read access to view models and organizations instead of requiring update permissions. (`apps/main/src/models/presentation/models.controller.ts`, [[1]](diffhunk://#diff-e785e67c4cc082787f03d703095f43dd067055c1ce6f91e503be47764bcd9e5aL87-R87) [[2]](diffhunk://#diff-e785e67c4cc082787f03d703095f43dd067055c1ce6f91e503be47764bcd9e5aL155-R155) [[3]](diffhunk://#diff-e785e67c4cc082787f03d703095f43dd067055c1ce6f91e503be47764bcd9e5aL183-R183) [[4]](diffhunk://#diff-e785e67c4cc082787f03d703095f43dd067055c1ce6f91e503be47764bcd9e5aL218-R218) [[5]](diffhunk://#diff-e785e67c4cc082787f03d703095f43dd067055c1ce6f91e503be47764bcd9e5aL260-R260) [[6]](diffhunk://#diff-e785e67c4cc082787f03d703095f43dd067055c1ce6f91e503be47764bcd9e5aL306-R306)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted permission validation requirements across multiple operations to ensure appropriate access control levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->