### PR TITLE
fix: use fallback version id for media schema

### DIFF
--- a/apps/main/src/media/infrastructure/media.service.ts
+++ b/apps/main/src/media/infrastructure/media.service.ts
@@ -22,6 +22,7 @@ export class MediaService {
   private readonly bucketNameDefault: string;
   private readonly bucketNameProfilePictures: string;
   private readonly pathDelimiter = "/";
+  private readonly fallbackMediaVersionId = "unversioned";
 
   private readonly configService: EnvService;
   private mediaDoc: Model<MediaDoc>;
@@ -147,7 +148,7 @@ export class MediaService {
       bucket: uploadInfo.location.bucket,
       objectName: uploadInfo.location.objectName,
       eTag: uploadInfo.info.etag,
-      versionId: uploadInfo.info.versionId || "1.0.0",
+      versionId: uploadInfo.info.versionId || this.fallbackMediaVersionId,
     });
     await this.save(media);
     return media;
@@ -195,7 +196,7 @@ export class MediaService {
       bucket: uploadInfo.location.bucket,
       objectName: uploadInfo.location.objectName,
       eTag: uploadInfo.info.etag,
-      versionId: uploadInfo.info.versionId || "1.0.0",
+      versionId: uploadInfo.info.versionId || this.fallbackMediaVersionId,
     });
     await this.save(media);
     return media;


### PR DESCRIPTION
This pull request makes a minor update to the default value for the `versionId` property in the `MediaService` class. If `uploadInfo.info.versionId` is not provided, it now defaults to `"1.0.0"` instead of an empty string.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures media uploads and product passport files now default to a consistent fallback version identifier ("unversioned") when no version is provided, preventing empty version values and improving version consistency across uploaded media.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->