### PR TITLE
Always light mode and api key longer expiration

### DIFF
--- a/apps/client/src/main.ts
+++ b/apps/client/src/main.ts
@@ -31,6 +31,9 @@ async function startApp() {
   app.use(PrimeVue, {
     theme: {
       preset: Aura,
+      options: {
+        darkModeSelector: false,
+      },
     },
   });
 

--- a/apps/client/src/view/integrations/IntegrationView.vue
+++ b/apps/client/src/view/integrations/IntegrationView.vue
@@ -40,12 +40,9 @@ const actions = computed(() => [
 ]);
 
 async function createApiKey() {
-  notificationStore.addErrorNotification(
-    t("integrations.apiKey.createError"),
-  );
   const { data, error } = await authClient.apiKey.create({
     name: "project-api-key",
-    expiresIn: 60 * 60 * 24 * 7,
+    expiresIn: 60 * 60 * 24 * 28,
     prefix: "project-api-key",
   });
   if (error) {


### PR DESCRIPTION
This pull request introduces a minor configuration update to the PrimeVue theme and a small adjustment to the API key expiration logic in the integrations view. The changes improve UI theme flexibility and extend the default API key validity period.

**UI Theme Configuration:**
* Disabled the `darkModeSelector` option in the PrimeVue theme setup within `main.ts`, which prevents users from toggling dark mode via the UI.

**API Key Expiration Adjustment:**
* Increased the default API key expiration from 7 days to 28 days in the `createApiKey` function in `IntegrationView.vue`, allowing API keys to remain valid for a longer period.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * API keys now expire after 28 days instead of 7 days, reducing frequent credential regeneration
  * Disabled automatic dark mode selector in theme configuration

* **Bug Fixes**
  * Removed unnecessary error notification appearing before API key creation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->