### PR TITLE
Updated `VIEW_ROOT_URL` to remove `/api` from `API_URL` using `replace` for correct base URL configuration.

### DIFF
--- a/apps/client/src/const.ts
+++ b/apps/client/src/const.ts
@@ -18,7 +18,7 @@ async function fetchConfig() {
 await fetchConfig();
 
 export const MARKETPLACE_URL = API_URL; // import.meta.env.VITE_MARKETPLACE_ROOT;
-export const VIEW_ROOT_URL = API_URL; // import.meta.env.VITE_VIEW_ROOT_URL;
+export const VIEW_ROOT_URL = API_URL.replace("/api", ""); // import.meta.env.VITE_VIEW_ROOT_URL;
 export const MEDIA_SERVICE_URL = API_URL; // import.meta.env.VITE_MEDIA_SERVICE_ROOT;
 export const AGENT_SERVER_URL = API_URL;
 export const ANALYTICS_URL = API_URL;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the base view URL to use the site root instead of the API path, preventing links from pointing to “/api”.
  * Fixed broken navigation and deep links that previously redirected to API endpoints.
  * Improved reliability of opening, sharing, and embedding pages that rely on the view URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->