### PR TITLE
Refactor: remove image resizing step from media service when processi…

### DIFF
--- a/apps/main/src/media/infrastructure/media.service.ts
+++ b/apps/main/src/media/infrastructure/media.service.ts
@@ -95,6 +95,12 @@ export class MediaService {
     );
   }
 
+  async processImageBuffer(buffer: Buffer) {
+    return await sharp(buffer)
+      .webp({ quality: 85 })
+      .toBuffer();
+  }
+
   async uploadFileOfProductPassport(
     originalFilename: string,
     buffer: Buffer,
@@ -120,9 +126,7 @@ export class MediaService {
     let fileTypeMime = fileType.mime;
     let uploadBuffer: Buffer = buffer;
     if (fileType.mime.startsWith("image/")) {
-      uploadBuffer = await sharp(buffer)
-        .webp({ quality: 85 })
-        .toBuffer();
+      uploadBuffer = await this.processImageBuffer(uploadBuffer);
       fileTypeMime = "image/webp";
     }
     const uploadInfo = await this.uploadFile(
@@ -166,10 +170,7 @@ export class MediaService {
     let fileTypeMime = fileType.mime;
     let uploadBuffer: Buffer = buffer;
     if (fileType.mime.startsWith("image/")) {
-      uploadBuffer = await sharp(buffer)
-        .resize({ width: 480, height: 480, fit: "cover" })
-        .webp({ quality: 85 })
-        .toBuffer();
+      uploadBuffer = await this.processImageBuffer(uploadBuffer);
       fileTypeMime = "image/webp";
     }
     const uuid = randomUUID();


### PR DESCRIPTION
This pull request makes a small update to the image processing logic in the `MediaService`. The change removes the resizing step for images before converting them to WebP format, so images are no longer automatically resized to 480x480 pixels.

* Removed image resizing (`resize({ width: 480, height: 480, fit: "cover" })`) before converting to WebP in the `MediaService` class (`media.service.ts`).…ng uploads

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated image upload processing: images are now converted to WebP (quality 85) and kept at their original dimensions instead of being resized to 480×480; uploaded media MIME is updated to image/webp. Other upload behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->