### PR TITLE
Fix: disable rate limiting on api keys

### DIFF
--- a/apps/main/src/auth/auth.service.ts
+++ b/apps/main/src/auth/auth.service.ts
@@ -173,6 +173,9 @@ export class AuthService implements OnModuleInit, OnModuleDestroy {
 
     const apiKeyPlugin = apiKey({
       enableSessionForAPIKeys: true,
+      rateLimit: {
+        enabled: false,
+      },
     });
     const plugins = [apiKeyPlugin, organizationPlugin];
     if (genericOAuthPlugin) {


### PR DESCRIPTION
This pull request introduces a minor configuration update to the `AuthService` in the authentication module. The change disables rate limiting for API keys by setting the `rateLimit.enabled` option to `false` in the API key plugin configuration.

* Disabled API key rate limiting by setting `rateLimit.enabled` to `false` in the `apiKey` plugin configuration in `auth.service.ts`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * API key rate limiting has been disabled, allowing API requests without throttling restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->