### PR TITLE
chore(deps): update pnpm to 10.26.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "open-dpp GmbH",
   "private": true,
   "license": "LGPL-3.0-only",
-  "packageManager": "pnpm@10.19.0",
+  "packageManager": "pnpm@10.26.1+sha512.664074abc367d2c9324fdc18037097ce0a8f126034160f709928e9e9f95d98714347044e5c3164d65bd5da6c59c6be362b107546292a8eecb7999196e5ce58fa",
   "devDependencies": {
     "@dotenvx/dotenvx": "^1.51.0",
     "turbo": "^2.6.1"


### PR DESCRIPTION
This pull request updates the `packageManager` field in the `package.json` file to use a newer version of `pnpm` with a specific SHA-512 hash for integrity verification. This ensures that the project uses a more recent and secure package manager version.

* Updated `packageManager` to `pnpm@10.26.1` with a SHA-512 integrity hash in `package.json` for improved security and reproducibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package manager version to the latest stable release.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->