### PR TITLE
chore(ci): remove Hetzner ARM runner setup from build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -151,22 +151,18 @@ jobs:
             runner: ubuntu-latest
             target: production
             image_suffix: ""
-            filter_path: main
           - platform: linux/amd64
             runner: ubuntu-latest
             target: mcpserver
             image_suffix: /mcp
-            filter_path: mcp
           - platform: linux/arm64
             runner: ubuntu-24.04-arm
             target: production
             image_suffix: ""
-            filter_path: main
           - platform: linux/arm64
             runner: ubuntu-24.04-arm
             target: mcpserver
             image_suffix: /mcp
-            filter_path: mcp
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout


### PR DESCRIPTION
This pull request simplifies the GitHub Actions workflow by removing the dynamic creation and deletion of Hetzner ARM runners and switching to a static self-hosted runner label for ARM builds. The main changes focus on workflow maintenance and reliability.

Workflow infrastructure changes:

* Removed the `create-runner` job that dynamically provisioned Hetzner ARM runners using the `Cyclenerd/hcloud-github-runner` action.
* Updated ARM build matrix entries in the `build-and-push` job to use the static `ubuntu-24.04-arm` runner label instead of referencing dynamically created runners.
* Removed the `delete-runner` job responsible for cleaning up Hetzner ARM runners after builds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflow simplified to use fixed ARM64 runners for more consistent builds.
  * Removed dynamic runner provisioning and orchestration steps.
  * Eliminated path-based conditional gating so builds run predictably without change filters.
  * Reduced transient workflow steps for a cleaner, more reliable build process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->