### PR TITLE
chore(deps): upgrade `@langchain/mcp-adapters` to 1.1.1 and update lo…

### DIFF
--- a/apps/main/package.json
+++ b/apps/main/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@langchain/core": "^0.3.80",
     "@langchain/langgraph": "^0.4.9",
-    "@langchain/mcp-adapters": "^0.6.0",
+    "@langchain/mcp-adapters": "^1.1.1",
     "@langchain/mistralai": "^0.2.3",
     "@langchain/ollama": "^0.2.4",
     "@modelcontextprotocol/sdk": "^1.25.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -197,8 +197,8 @@ importers:
         specifier: ^0.4.9
         version: 0.4.9(@langchain/core@0.3.80(openai@5.12.2(ws@8.18.3)(zod@4.2.1)))(zod-to-json-schema@3.25.0(zod@4.2.1))
       '@langchain/mcp-adapters':
-        specifier: ^0.6.0
-        version: 0.6.0(@cfworker/json-schema@4.1.1)(@langchain/core@0.3.80(openai@5.12.2(ws@8.18.3)(zod@4.2.1)))(hono@4.11.1)
+        specifier: ^1.1.1
+        version: 1.1.1(@cfworker/json-schema@4.1.1)(@langchain/core@0.3.80(openai@5.12.2(ws@8.18.3)(zod@4.2.1)))(@langchain/langgraph@0.4.9(@langchain/core@0.3.80(openai@5.12.2(ws@8.18.3)(zod@4.2.1)))(zod-to-json-schema@3.25.0(zod@4.2.1)))(hono@4.11.1)
       '@langchain/mistralai':
         specifier: ^0.2.3
         version: 0.2.3(@langchain/core@0.3.80(openai@5.12.2(ws@8.18.3)(zod@4.2.1)))
@@ -2045,11 +2045,12 @@ packages:
       zod-to-json-schema:
         optional: true
 
-  '@langchain/mcp-adapters@0.6.0':
-    resolution: {integrity: sha512-NHQNH9NciLhxlCnL/4HDebiYT3UQvpBfF5KPlIi/uSXn8te/bYjPV64gUyAloNNo+fjj4qDvKP1/nHj0r7fKFw==}
-    engines: {node: '>=18'}
+  '@langchain/mcp-adapters@1.1.1':
+    resolution: {integrity: sha512-oMnozcaZ9e4SzPIcA8EfrSxT7TForMvPfGrUj+l/a+qHS2zcSMOSUH11joy4YwGiRVQgO/68TK8ceukWaeLbDw==}
+    engines: {node: '>=20.10.0'}
     peerDependencies:
-      '@langchain/core': ^0.3.66
+      '@langchain/core': ^1.0.0
+      '@langchain/langgraph': ^1.0.0
 
   '@langchain/mistralai@0.2.3':
     resolution: {integrity: sha512-U2gaoRF7zilpc5pvdSoPTpYWo/vF47PPeHwCwd98RSFBracEZ3WGJ4zoXTqM7+4/WF3bTbDZ5f6+YO2PDX66qQ==}
@@ -10671,12 +10672,13 @@ snapshots:
       - react
       - react-dom
 
-  '@langchain/mcp-adapters@0.6.0(@cfworker/json-schema@4.1.1)(@langchain/core@0.3.80(openai@5.12.2(ws@8.18.3)(zod@4.2.1)))(hono@4.11.1)':
+  '@langchain/mcp-adapters@1.1.1(@cfworker/json-schema@4.1.1)(@langchain/core@0.3.80(openai@5.12.2(ws@8.18.3)(zod@4.2.1)))(@langchain/langgraph@0.4.9(@langchain/core@0.3.80(openai@5.12.2(ws@8.18.3)(zod@4.2.1)))(zod-to-json-schema@3.25.0(zod@4.2.1)))(hono@4.11.1)':
     dependencies:
       '@langchain/core': 0.3.80(openai@5.12.2(ws@8.18.3)(zod@4.2.1))
-      '@modelcontextprotocol/sdk': 1.25.1(@cfworker/json-schema@4.1.1)(hono@4.11.1)(zod@3.25.76)
+      '@langchain/langgraph': 0.4.9(@langchain/core@0.3.80(openai@5.12.2(ws@8.18.3)(zod@4.2.1)))(zod-to-json-schema@3.25.0(zod@4.2.1))
+      '@modelcontextprotocol/sdk': 1.25.1(@cfworker/json-schema@4.1.1)(hono@4.11.1)(zod@4.2.1)
       debug: 4.4.3(supports-color@8.1.1)
-      zod: 3.25.76
+      zod: 4.2.1
     optionalDependencies:
       extended-eventsource: 1.7.0
     transitivePeerDependencies:


### PR DESCRIPTION
This pull request updates the `@langchain/mcp-adapters` dependency to version 1.1.1 across the project, ensuring compatibility with newer versions of its peer dependencies and Node.js. The update affects both the main `package.json` and the lockfile, reflecting changes in required peer dependencies and supported Node.js versions.

**Dependency Upgrade:**

* Upgraded `@langchain/mcp-adapters` from version 0.6.0 to 1.1.1 in `package.json`, ensuring the project uses the latest features and fixes from this package.
* Updated the lockfile (`pnpm-lock.yaml`) to reference `@langchain/mcp-adapters@1.1.1` throughout, including importers, package resolution, and snapshots. This includes:
  - Changing peer dependency requirements to `@langchain/core@^1.0.0` and `@langchain/langgraph@^1.0.0`
  - Updating required Node.js engine to `>=20.10.0`
  - Updating transitive dependencies such as `zod` from version 3.x to 4.x [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL200-R201) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL2048-R2053) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL10674-R10681)…ckfile

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependencies to the latest compatible versions for improved stability and security.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->