### PR TITLE
Add `uuid` dependency (v13.0.0) to `package.json` and update `pnpm-lock.yaml`. Remove redundant `uuid` entry from `dependencies`.

### DIFF
--- a/apps/main/package.json
+++ b/apps/main/package.json
@@ -73,6 +73,7 @@
     "sharp": "^0.34.5",
     "socket.io": "^4.8.2",
     "socket.io-client": "^4.8.2",
+    "uuid": "^13.0.0",
     "zod": "^4.3.6",
     "zod-openapi": "^5.4.5"
   },
@@ -113,7 +114,6 @@
     "ts-node": "^10.9.2",
     "tsconfig-paths": "^4.2.0",
     "typescript": "^5.9.3",
-    "typescript-eslint": "^8.54.0",
-    "uuid": "^13.0.0"
+    "typescript-eslint": "^8.54.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -376,6 +376,9 @@ importers:
       socket.io-client:
         specifier: ^4.8.2
         version: 4.8.3
+      uuid:
+        specifier: ^13.0.0
+        version: 13.0.0
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -494,9 +497,6 @@ importers:
       typescript-eslint:
         specifier: ^8.54.0
         version: 8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
-      uuid:
-        specifier: ^13.0.0
-        version: 13.0.0
 
   packages/api-client:
     dependencies:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency configuration to optimize runtime requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->