### PR TITLE
refactor(tests): remove multiple MongoMemoryServers

### DIFF
--- a/apps/main/src/identity/auth/infrastructure/schemas/session.schema.spec.ts
+++ b/apps/main/src/identity/auth/infrastructure/schemas/session.schema.spec.ts
@@ -1,16 +1,13 @@
 import { expect } from "@jest/globals";
-import { MongoMemoryServer } from "mongodb-memory-server";
 import { connect, Connection, Model } from "mongoose";
 import { Session, SessionSchema } from "./session.schema";
 
 describe("sessionSchema", () => {
-  let mongod: MongoMemoryServer;
   let mongoConnection: Connection;
   let SessionModel: Model<Session>;
 
   beforeAll(async () => {
-    mongod = await MongoMemoryServer.create();
-    const uri = mongod.getUri();
+    const uri = process.env.OPEN_DPP_MONGODB_URI!;
     mongoConnection = (await connect(uri)).connection;
     SessionModel = mongoConnection.model(Session.name, SessionSchema);
     await SessionModel.createIndexes();
@@ -30,7 +27,6 @@ describe("sessionSchema", () => {
       await collections[key].drop();
     }
     await mongoConnection.close();
-    await mongod.stop();
   });
 
   it("should create a session document", async () => {

--- a/apps/main/src/identity/organizations/infrastructure/schemas/invitation.schema.spec.ts
+++ b/apps/main/src/identity/organizations/infrastructure/schemas/invitation.schema.spec.ts
@@ -1,18 +1,15 @@
 import { expect } from "@jest/globals";
-import { MongoMemoryServer } from "mongodb-memory-server";
 import { connect, Connection, Model } from "mongoose";
 import { InvitationStatus } from "../../domain/invitation-status.enum";
 import { MemberRole } from "../../domain/member-role.enum";
 import { Invitation, InvitationSchema } from "./invitation.schema";
 
 describe("invitationSchema", () => {
-  let mongod: MongoMemoryServer;
   let mongoConnection: Connection;
   let InvitationModel: Model<Invitation>;
 
   beforeAll(async () => {
-    mongod = await MongoMemoryServer.create();
-    const uri = mongod.getUri();
+    const uri = process.env.OPEN_DPP_MONGODB_URI!;
     mongoConnection = (await connect(uri)).connection;
     InvitationModel = mongoConnection.model(Invitation.name, InvitationSchema);
   });
@@ -26,9 +23,7 @@ describe("invitationSchema", () => {
   });
 
   afterAll(async () => {
-    await mongoConnection.dropDatabase();
     await mongoConnection.close();
-    await mongod.stop();
   });
 
   it("should create an invitation document", async () => {

--- a/apps/main/src/identity/organizations/infrastructure/schemas/member.schema.spec.ts
+++ b/apps/main/src/identity/organizations/infrastructure/schemas/member.schema.spec.ts
@@ -1,17 +1,14 @@
 import { expect } from "@jest/globals";
-import { MongoMemoryServer } from "mongodb-memory-server";
 import { connect, Connection, Model, Types } from "mongoose";
 import { MemberRole } from "../../domain/member-role.enum";
 import { Member, MemberSchema } from "./member.schema";
 
 describe("memberSchema", () => {
-  let mongod: MongoMemoryServer;
   let mongoConnection: Connection;
   let MemberModel: Model<Member>;
 
   beforeAll(async () => {
-    mongod = await MongoMemoryServer.create();
-    const uri = mongod.getUri();
+    const uri = process.env.OPEN_DPP_MONGODB_URI!;
     mongoConnection = (await connect(uri)).connection;
     MemberModel = mongoConnection.model(Member.name, MemberSchema);
   });
@@ -25,9 +22,7 @@ describe("memberSchema", () => {
   });
 
   afterAll(async () => {
-    await mongoConnection.dropDatabase();
     await mongoConnection.close();
-    await mongod.stop();
   });
 
   it("should create a member document", async () => {

--- a/apps/main/src/identity/organizations/infrastructure/schemas/organization.schema.spec.ts
+++ b/apps/main/src/identity/organizations/infrastructure/schemas/organization.schema.spec.ts
@@ -1,17 +1,14 @@
 import { expect } from "@jest/globals";
 import { ObjectId } from "mongodb";
-import { MongoMemoryServer } from "mongodb-memory-server";
 import { connect, Connection, Model } from "mongoose";
 import { Organization, OrganizationSchema } from "./organization.schema";
 
 describe("organizationSchema", () => {
-  let mongod: MongoMemoryServer;
   let mongoConnection: Connection;
   let OrganizationModel: Model<Organization>;
 
   beforeAll(async () => {
-    mongod = await MongoMemoryServer.create();
-    const uri = mongod.getUri();
+    const uri = process.env.OPEN_DPP_MONGODB_URI!;
     mongoConnection = (await connect(uri)).connection;
     OrganizationModel = mongoConnection.model(Organization.name, OrganizationSchema);
   });
@@ -25,9 +22,7 @@ describe("organizationSchema", () => {
   });
 
   afterAll(async () => {
-    await mongoConnection.dropDatabase();
     await mongoConnection.close();
-    await mongod.stop();
   });
 
   it("should create an organization document", async () => {

--- a/apps/main/src/identity/users/infrastructure/schemas/account.schema.spec.ts
+++ b/apps/main/src/identity/users/infrastructure/schemas/account.schema.spec.ts
@@ -1,16 +1,13 @@
 import { expect } from "@jest/globals";
-import { MongoMemoryServer } from "mongodb-memory-server";
 import { connect, Connection, Model } from "mongoose";
 import { Account, AccountSchema } from "./account.schema";
 
 describe("accountSchema", () => {
-  let mongod: MongoMemoryServer;
   let mongoConnection: Connection;
   let AccountModel: Model<Account>;
 
   beforeAll(async () => {
-    mongod = await MongoMemoryServer.create();
-    const uri = mongod.getUri();
+    const uri = process.env.OPEN_DPP_MONGODB_URI!;
     mongoConnection = (await connect(uri)).connection;
     AccountModel = mongoConnection.model(Account.name, AccountSchema);
   });
@@ -24,9 +21,7 @@ describe("accountSchema", () => {
   });
 
   afterAll(async () => {
-    await mongoConnection.dropDatabase();
     await mongoConnection.close();
-    await mongod.stop();
   });
 
   it("should create an account document", async () => {

--- a/apps/main/src/identity/users/infrastructure/schemas/user.schema.spec.ts
+++ b/apps/main/src/identity/users/infrastructure/schemas/user.schema.spec.ts
@@ -1,18 +1,15 @@
 import { expect } from "@jest/globals";
 import { ObjectId } from "mongodb";
-import { MongoMemoryServer } from "mongodb-memory-server";
 import { connect, Connection, Model } from "mongoose";
 import { UserRole } from "../../domain/user-role.enum";
 import { User, UserSchema } from "./user.schema";
 
 describe("userSchema", () => {
-  let mongod: MongoMemoryServer;
   let mongoConnection: Connection;
   let UserModel: Model<User>;
 
   beforeAll(async () => {
-    mongod = await MongoMemoryServer.create();
-    const uri = mongod.getUri();
+    const uri = process.env.OPEN_DPP_MONGODB_URI!;
     mongoConnection = (await connect(uri)).connection;
     UserModel = mongoConnection.model(User.name, UserSchema);
   });
@@ -26,9 +23,7 @@ describe("userSchema", () => {
   });
 
   afterAll(async () => {
-    await mongoConnection.dropDatabase();
     await mongoConnection.close();
-    await mongod.stop();
   });
 
   it("should create a user document", async () => {


### PR DESCRIPTION
This pull request updates the test setup for several Mongoose schema test files by removing the use of the `mongodb-memory-server` in favor of connecting directly to a MongoDB instance specified by the `OPEN_DPP_MONGODB_URI` environment variable. This change simplifies the test configuration and aligns all test files with a consistent database connection approach.

**Test infrastructure changes:**

* Replaced the in-memory MongoDB server (`mongodb-memory-server`) with a direct connection to the database using the `OPEN_DPP_MONGODB_URI` environment variable in all affected schema test files (`account.schema.spec.ts`, `user.schema.spec.ts`, `organization.schema.spec.ts`, `member.schema.spec.ts`, `invitation.schema.spec.ts`, `session.schema.spec.ts`). [[1]](diffhunk://#diff-015879615e08b36a141e9c31e953ea958dde0e0b649c905cf343a021dba320a6L2-R10) [[2]](diffhunk://#diff-547fd0a85acbcd14b13f97c32cc240540b5a57033eec2604c59899a64a4b31bfL3-R12) [[3]](diffhunk://#diff-2f1b99602d66b889977e957257473434d91ae0a04f1e05392984414770948199L3-R11) [[4]](diffhunk://#diff-414ffe585948b02c41f5736a9a6591735d9659ed75eb7a133534ec8b0f765d35L2-R11) [[5]](diffhunk://#diff-4cf51fa6c8190a0ec75f596e4e108003e16e74d81446072d073545e19f6b3f65L2-R12) [[6]](diffhunk://#diff-ed956cd91b79fcab276d52aa1e18726e19445a0ce15ce1d40380cb4f1f48dc3dL2-R10)

* Removed all setup and teardown logic related to the in-memory server, including dropping the database and stopping the server in `afterAll` hooks. Tests now only close the MongoDB connection after completion. [[1]](diffhunk://#diff-015879615e08b36a141e9c31e953ea958dde0e0b649c905cf343a021dba320a6L27-L29) [[2]](diffhunk://#diff-547fd0a85acbcd14b13f97c32cc240540b5a57033eec2604c59899a64a4b31bfL29-L31) [[3]](diffhunk://#diff-2f1b99602d66b889977e957257473434d91ae0a04f1e05392984414770948199L28-L30) [[4]](diffhunk://#diff-414ffe585948b02c41f5736a9a6591735d9659ed75eb7a133534ec8b0f765d35L28-L30) [[5]](diffhunk://#diff-4cf51fa6c8190a0ec75f596e4e108003e16e74d81446072d073545e19f6b3f65L29-L31) [[6]](diffhunk://#diff-ed956cd91b79fcab276d52aa1e18726e19445a0ce15ce1d40380cb4f1f48dc3dL33)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test infrastructure across multiple modules to connect to an external MongoDB instance via environment configuration instead of using in-memory server setup. Tests maintain existing validation logic while using shared database resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->