### PR TITLE
Fix syntax for OPEN_DPP_MAIL_HOST in build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,7 @@ jobs:
       OPEN_DPP_CLAMAV_URL: "http://clamav-rest"
       OPEN_DPP_CLAMAV_PORT: "9000"
       # Mail
-      OPEN_DPP_MAIL_HOST=: "localhost"
+      OPEN_DPP_MAIL_HOST: "localhost"
       OPEN_DPP_MAIL_PORT: "8026"
       OPEN_DPP_MAIL_USER: "admin"
       OPEN_DPP_MAIL_PASSWORD: "admin"


### PR DESCRIPTION
## Description
Fixed a typo in the GitHub Actions CI workflow where an erroneous `=` character was included in the environment variable name.

 ## Changes
 Removed `=` from `OPEN_DPP_MAIL_HOST=:` → `OPEN_DPP_MAIL_HOST:`

 ## Why
 This would have caused `process.env.OPEN_DPP_MAIL_HOST` to be undefined, breaking any mail-related functionality in tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a build configuration issue in the test environment to ensure proper system setup and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->