### PR TITLE
Fix const.ts for deployments

### DIFF
--- a/apps/client/src/const.ts
+++ b/apps/client/src/const.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line import/no-mutable-exports
-export let API_URL = (import.meta.env.VITE_API_ROOT as string) || "http://localhost:3000/api";
+export let API_URL = import.meta.env.VITE_API_ROOT as string;
 export const APPEND_TO = import.meta.env.VITE_APPEND_TO as string ?? "body"; // This is set to self for cypress component tests to fix rendering issues for primevue components using teleport like SplitButton
 async function fetchConfig() {
   if (!API_URL) {


### PR DESCRIPTION
This pull request makes a minor adjustment to the way the `API_URL` constant is initialized in `const.ts`. The default fallback value for `API_URL` is removed, so it now relies solely on the `VITE_API_ROOT` environment variable being set.

* Removed the fallback value (`"http://localhost:3000/api"`) for `API_URL`, so it is now strictly determined by the `VITE_API_ROOT` environment variable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated API configuration initialization to dynamically fetch runtime configuration when the API root environment variable is not set, replacing the previous static default value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->