### PR TITLE
Remove `hasUniqueLanguagesOrFail` validation from `displayName` setters across submodel elements.

### DIFF
--- a/apps/main/src/aas/domain/submodel-base/file.ts
+++ b/apps/main/src/aas/domain/submodel-base/file.ts
@@ -30,7 +30,6 @@ export class File implements ISubmodelElement {
   }
 
   set displayName(value: Array<LanguageText>) {
-    hasUniqueLanguagesOrFail(value);
     this._displayName = value;
   }
 

--- a/apps/main/src/aas/domain/submodel-base/property.ts
+++ b/apps/main/src/aas/domain/submodel-base/property.ts
@@ -41,7 +41,6 @@ export class Property implements ISubmodelElement {
   }
 
   set displayName(value: Array<LanguageText>) {
-    hasUniqueLanguagesOrFail(value);
     this._displayName = value;
   }
 

--- a/apps/main/src/aas/domain/submodel-base/reference-element.ts
+++ b/apps/main/src/aas/domain/submodel-base/reference-element.ts
@@ -29,7 +29,6 @@ export class ReferenceElement implements ISubmodelElement {
   }
 
   set displayName(value: Array<LanguageText>) {
-    hasUniqueLanguagesOrFail(value);
     this._displayName = value;
   }
 

--- a/apps/main/src/aas/domain/submodel-base/submodel-element-collection.ts
+++ b/apps/main/src/aas/domain/submodel-base/submodel-element-collection.ts
@@ -36,7 +36,6 @@ export class SubmodelElementCollection implements ISubmodelElement {
   }
 
   set displayName(value: Array<LanguageText>) {
-    hasUniqueLanguagesOrFail(value);
     this._displayName = value;
   }
 

--- a/apps/main/src/aas/domain/submodel-base/submodel-element-list.ts
+++ b/apps/main/src/aas/domain/submodel-base/submodel-element-list.ts
@@ -39,7 +39,6 @@ export class SubmodelElementList implements ISubmodelElement {
   }
 
   set displayName(value: Array<LanguageText>) {
-    hasUniqueLanguagesOrFail(value);
     this._displayName = value;
   }
 

--- a/apps/main/src/aas/domain/submodel-base/submodel.ts
+++ b/apps/main/src/aas/domain/submodel-base/submodel.ts
@@ -50,7 +50,6 @@ export class Submodel implements ISubmodelBase, IPersistable {
   }
 
   set displayName(value: Array<LanguageText>) {
-    hasUniqueLanguagesOrFail(value);
     this._displayName = value;
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed overly restrictive validation that previously prevented setting display name fields without enforcing unique language entries. Display names can now be assigned more flexibly across all domain model classes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->