### PR TITLE
fix(translations): correct spelling of "Signin" to "Sign in" in auth …

### DIFF
--- a/apps/client/src/translations/en-US.json
+++ b/apps/client/src/translations/en-US.json
@@ -530,8 +530,8 @@
       "title": "Signup a new account",
       "button": "Signup",
       "alreadyAMember": "Already a member?",
-      "ctaSignIn": "Signin now",
-      "error": "Signup failed."
+      "ctaSignIn": "Sign in now",
+      "error": "Sign up failed."
     },
     "passwordResetRequest": {
       "title": "Request password reset",


### PR DESCRIPTION
…section

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected "Signin" → "Sign in" on the sign-in button.
  * Corrected "Signin now" → "Sign in now" on the sign-up CTA.
  * Corrected "Signup failed." → "Sign up failed." in the sign-up error message.
  * Improves consistency and clarity of authentication UI text for end users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->