### PR TITLE
Use `UserRole.USER` as the default role for users with undefined roles.

### DIFF
--- a/apps/client/src/stores/user.ts
+++ b/apps/client/src/stores/user.ts
@@ -45,7 +45,7 @@ export const useUserStore = defineStore("user", (): IUserStore => {
     session: { user: BetterAuthSession } | null,
   ) {
     if (session) {
-      user.value.role = session.user.role ? UserRoleDtoEnum.parse(session.user.role) : UserRoleDto.ANONYMOUS;
+      user.value.role = session.user.role ? UserRoleDtoEnum.parse(session.user.role) : UserRoleDto.USER;
       user.value.id = session.user.id;
     }
     else {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the default user role assignment during session-based authentication to ensure users are assigned the appropriate role level.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->