### PR TITLE
Introduce `ignoredPermissionOptions` to `PermissionsForm` for filtering specific permissions:

### DIFF
--- a/apps/client/src/components/aas/PermissionsForm.vue
+++ b/apps/client/src/components/aas/PermissionsForm.vue
@@ -39,6 +39,7 @@ const {
   object: props.path.idShortPathIncludingSubmodel ?? "",
   modifyShell: props.modifyShell,
   deletePolicyBySubjectAndObject: props.deletePolicyBySubjectAndObject,
+  ignoredPermissionOptions: props.ignoredPermissionOptions,
 });
 
 const { asSubject } = useUserStore();
@@ -111,6 +112,15 @@ const permissionsInherited = computed(
   () => permissionsOfSelectedRole.value.inheritsPermissionsOf !== null,
 );
 
+function isReadDisabledCauseOfOtherPermissionsAreActive(key: PermissionType) {
+  return (
+    key === Permissions.Read
+    && permissionsOfSelectedRole.value.permissions.some(
+      p => p !== Permissions.Read,
+    )
+  );
+}
+
 defineExpose<{
   savePermissions: () => Promise<void>;
 }>({
@@ -158,10 +168,7 @@ defineExpose<{
             disabled
               || !canEditPermissions
               || permissionsInherited
-              || (permission.key === Permissions.Read
-                && permissionsOfSelectedRole.permissions.some(
-                  (p) => p !== Permissions.Read,
-                ))
+              || isReadDisabledCauseOfOtherPermissionsAreActive(permission.key)
           "
           name="permissions"
           :value="permission.key"

--- a/apps/client/src/composables/aas-permissions-form.spec.ts
+++ b/apps/client/src/composables/aas-permissions-form.spec.ts
@@ -157,6 +157,72 @@ describe("aasPermissionsForm composable", () => {
     ).toEqual({ subject: member, permissions: allPermissionsAllow.map(p => p.permission), inheritsPermissionsOf: null });
   });
 
+  it("should consider ignorePermissionsOptions", async () => {
+    const transientParams: SecurityPlainTransientParams = {
+      policies: [
+        {
+          subject: {
+            userRole: UserRoleDto.USER,
+            memberRole: MemberRoleDto.MEMBER,
+          },
+          object: { idShortPath: "section1" },
+          permissions: [
+            {
+              permission: Permissions.Read,
+              kindOfPermission: PermissionKind.Allow,
+            },
+            {
+              permission: Permissions.Create,
+              kindOfPermission: PermissionKind.Allow,
+            },
+          ],
+        },
+      ],
+    };
+    const security: SecurityResponseDto = securityPlainFactory.build(
+      undefined,
+      { transient: transientParams },
+    );
+    const owner = {
+      userRole: UserRoleDto.USER,
+      memberRole: MemberRoleDto.OWNER,
+    };
+    mocks.asSubject.mockReturnValue(owner);
+    const { editPermissions, permissions } = mountHarness({
+      getAccessPermissionRules: () =>
+        security.localAccessControl.accessPermissionRules,
+      object: "section1.prop1",
+      modifyShell: modifyShellMock,
+      deletePolicyBySubjectAndObject: deletePolicyMock,
+      ignoredPermissionOptions: [Permissions.Create],
+    });
+    const member = { userRole: UserRoleDto.USER, memberRole: MemberRoleDto.MEMBER };
+    expect(
+      permissions.value.find(p => isEqualSubject(p.subject, member)),
+    ).toEqual({
+      subject: member,
+      permissions: [Permissions.Read],
+      inheritsPermissionsOf: "section1",
+    });
+    editPermissions([Permissions.Edit], member);
+    expect(
+      permissions.value.find(p => isEqualSubject(p.subject, member)),
+    ).toEqual({
+      subject: member,
+      permissions: [Permissions.Edit, Permissions.Read],
+      inheritsPermissionsOf: null,
+    });
+    editPermissions([], member);
+
+    expect(
+      permissions.value.find(p => isEqualSubject(p.subject, member)),
+    ).toEqual({
+      subject: member,
+      permissions: [],
+      inheritsPermissionsOf: null,
+    });
+  });
+
   it("should modify permissions", async () => {
     const transientParams: SecurityPlainTransientParams = {
       policies: [

--- a/apps/client/src/composables/aas-permissions-form.ts
+++ b/apps/client/src/composables/aas-permissions-form.ts
@@ -33,6 +33,7 @@ export interface AasPermissionsFormProps {
   getAccessPermissionRules: () => AccessPermissionRuleResponseDto[];
   modifyShell: (data: AssetAdministrationShellModificationDto) => Promise<void>;
   deletePolicyBySubjectAndObject: (data: DeletePolicyDto) => Promise<void>;
+  ignoredPermissionOptions?: PermissionType[];
 }
 
 export function useAasPermissionsForm({
@@ -40,6 +41,7 @@ export function useAasPermissionsForm({
   object,
   modifyShell,
   deletePolicyBySubjectAndObject,
+  ignoredPermissionOptions,
 }: AasPermissionsFormProps): IAasPermissionsForm {
   const { canEditPermissionsOfRole, hierarchy } = useRoleHierarchy();
   const { asSubject } = useUserStore();
@@ -90,7 +92,9 @@ export function useAasPermissionsForm({
     // Create / Edit / Delete do not make sense without Read permission
     if (
       !newPermissions.includes(Permissions.Read)
-      && newPermissions.some(p => p !== Permissions.Read)
+      && newPermissions.some(
+        p => p !== Permissions.Read && !(ignoredPermissionOptions && ignoredPermissionOptions.includes(p)),
+      )
     ) {
       allowedPermissions.push({
         permission: Permissions.Read,
@@ -139,7 +143,12 @@ export function useAasPermissionsForm({
     const allSubjects = hierarchy.map(role => role.key);
     for (const subject of allSubjects) {
       const { permissions, inheritsPermissionsOf } = getPermissionsForSubject(subject);
-      allPermissions.push({ subject, permissions, inheritsPermissionsOf });
+      let filteredPermissions = permissions;
+      if (ignoredPermissionOptions) {
+        filteredPermissions = permissions.filter(p => !ignoredPermissionOptions.includes(p));
+      }
+
+      allPermissions.push({ subject, permissions: filteredPermissions, inheritsPermissionsOf });
     }
     return allPermissions;
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for excluding specific permission options from the permissions management form, enabling more flexible and granular permission control across the application.

* **Bug Fixes**
  * Improved the Read permission checkbox disabled state to better handle cases where multiple permissions are simultaneously active on a role.

* **Tests**
  * Added test coverage validating behavior when specific permission options are excluded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->