### PR TITLE
Add support for copying AAS, submodels, and environment with permissions:

### DIFF
--- a/apps/client/src/composables/aas-editor.ts
+++ b/apps/client/src/composables/aas-editor.ts
@@ -554,8 +554,8 @@ export function useAasEditor({
   const createSubmodel = async () => {
     async function createCallback(data: SubmodelRequestDto) {
       const response = await aasNamespace.createSubmodel(id, data);
-      await finalizeApiRequest(response);
       await fetchAssetAdministrationShell();
+      await finalizeApiRequest(response);
     }
     drawer.openDrawer({
       type: KeyTypes.Submodel,

--- a/apps/main/src/aas/domain/asset-administration-shell.spec.ts
+++ b/apps/main/src/aas/domain/asset-administration-shell.spec.ts
@@ -85,6 +85,87 @@ describe("assetAdministrationShell", () => {
     ]);
   });
 
+  it("should copy aas", () => {
+    const submodelId1 = "submodelId1";
+    const submodel1 = Submodel.create({ id: submodelId1, idShort: "s1" });
+    const submodelRef1 = submodelToReference(submodel1);
+    const submodelId2 = "submodelId2";
+    const submodel2 = Submodel.create({ id: submodelId2, idShort: "s2" });
+    const submodelRef2 = submodelToReference(submodel2);
+
+    const admin = SubjectAttributes.create({ userRole: UserRole.ADMIN });
+    const security = Security.create({});
+    security.addPolicy(admin, IdShortPath.create({ path: submodel1.idShort }), allPermissionsAllow.map(Permission.fromPlain));
+    security.addPolicy(admin, IdShortPath.create({ path: submodel2.idShort }), allPermissionsAllow.map(Permission.fromPlain));
+    const member = SubjectAttributes.create({ userRole: UserRole.USER, memberRole: MemberRole.MEMBER });
+    security.addPolicy(member, IdShortPath.create({ path: submodel1.idShort }), allPermissionsAllow.map(Permission.fromPlain));
+
+    const aas = AssetAdministrationShell.create({
+      id: "aasId",
+      assetInformation: AssetInformation.create({ assetKind: AssetKind.Instance, globalAssetId: "aasId" }),
+      submodels: [submodelRef1, submodelRef2],
+      security,
+    });
+
+    const copyS1 = submodel1.copy();
+    const copyS2 = submodel2.copy();
+    const copy = aas.copy([copyS1, copyS2]);
+    expect(copy.id).not.toEqual(aas.id);
+    expect(copy.assetInformation).toEqual({ ...aas.assetInformation, globalAssetId: copy.id });
+    expect(copy.submodels).toEqual([submodelToReference(copyS1), submodelToReference(copyS2)]);
+
+    expect(copy.security.localAccessControl.accessPermissionRules).toEqual([
+      AccessPermissionRule.create({
+        targetSubjectAttributes: admin,
+        permissionsPerObject: [
+          PermissionPerObject.create({
+            object: createAasObject(IdShortPath.create({ path: copyS1.idShort })),
+            permissions: allPermissionsAllow.map(Permission.fromPlain),
+          }),
+          PermissionPerObject.create({
+            object: createAasObject(IdShortPath.create({ path: copyS2.idShort })),
+            permissions: allPermissionsAllow.map(Permission.fromPlain),
+          }),
+        ],
+      }),
+      AccessPermissionRule.create({
+        targetSubjectAttributes: member,
+        permissionsPerObject: [
+          PermissionPerObject.create({
+            object: createAasObject(IdShortPath.create({ path: copyS1.idShort })),
+            permissions: allPermissionsAllow.map(Permission.fromPlain),
+          }),
+        ],
+      }),
+    ]);
+
+    const copyWithoutS2 = aas.copy([copyS1]);
+    expect(copyWithoutS2.id).not.toEqual(aas.id);
+    expect(copyWithoutS2.assetInformation).toEqual({ ...aas.assetInformation, globalAssetId: copyWithoutS2.id });
+    expect(copyWithoutS2.submodels).toEqual([submodelToReference(copyS1)]);
+
+    expect(copyWithoutS2.security.localAccessControl.accessPermissionRules).toEqual([
+      AccessPermissionRule.create({
+        targetSubjectAttributes: admin,
+        permissionsPerObject: [
+          PermissionPerObject.create({
+            object: createAasObject(IdShortPath.create({ path: copyS1.idShort })),
+            permissions: allPermissionsAllow.map(Permission.fromPlain),
+          }),
+        ],
+      }),
+      AccessPermissionRule.create({
+        targetSubjectAttributes: member,
+        permissionsPerObject: [
+          PermissionPerObject.create({
+            object: createAasObject(IdShortPath.create({ path: copyS1.idShort })),
+            permissions: allPermissionsAllow.map(Permission.fromPlain),
+          }),
+        ],
+      }),
+    ]);
+  });
+
   it("should be modified", () => {
     const aas = AssetAdministrationShell.create({
       assetInformation: AssetInformation.create({ assetKind: AssetKind.Instance, globalAssetId: "globalAssetId" }),
@@ -105,37 +186,6 @@ describe("assetAdministrationShell", () => {
     expect(aas.assetInformation.assetKind).toEqual(AssetKind.Instance);
     expect(aas.assetInformation.globalAssetId).toEqual("globalAssetId");
     expect(aas.assetInformation.defaultThumbnails).toEqual(defaultThumbnails.map(Resource.fromPlain));
-  });
-
-  it("should be able to be copied", () => {
-    const id = "aasId";
-    const aas = AssetAdministrationShell.create({
-      id,
-      assetInformation: AssetInformation.create({ assetKind: "Instance", globalAssetId: id }),
-    });
-
-    const submodel = Submodel.create({
-      id: randomUUID(),
-      idShort: "MySubmodel",
-    });
-
-    aas.addSubmodel(submodel);
-
-    const submodelCopy = submodel.copy();
-
-    const copy = aas.copy([submodelCopy]);
-
-    expect(copy.id).not.toEqual(aas.id);
-    expect(copy.assetInformation).toEqual({ ...aas.assetInformation, globalAssetId: copy.id });
-    expect(copy.submodels).toEqual([
-      Reference.create({
-        type: ReferenceTypes.ModelReference,
-        keys: [Key.create({
-          type: KeyTypes.Submodel,
-          value: submodelCopy.id,
-        })],
-      }),
-    ]);
   });
 
   it("should add a submodel", () => {

--- a/apps/main/src/aas/domain/asset-adminstration-shell.ts
+++ b/apps/main/src/aas/domain/asset-adminstration-shell.ts
@@ -138,7 +138,7 @@ export class AssetAdministrationShell implements IIdentifiable, IHasDataSpecific
    */
   copy(submodels: Submodel[]): AssetAdministrationShell {
     const copyId = randomUUID();
-    const plain = this.toPlain();
+    const plain = this.toPlain({ context: { filterSubmodels: submodels } });
     const copy = AssetAdministrationShell.fromPlain({
       ...plain,
       id: copyId,

--- a/apps/main/src/aas/domain/copy-options.ts
+++ b/apps/main/src/aas/domain/copy-options.ts
@@ -1,0 +1,4 @@
+import { JsonVisitorContextType } from "./json-visitor";
+import { AasAbility } from "./security/aas-ability";
+
+export interface ICopyOptions { ability?: AasAbility; context?: JsonVisitorContextType }

--- a/apps/main/src/aas/domain/submodel-base/submodel.spec.ts
+++ b/apps/main/src/aas/domain/submodel-base/submodel.spec.ts
@@ -403,6 +403,33 @@ describe("submodel", () => {
     expect(submodel.toPlain({ ability })).toEqual({ ...submodel.toPlain(), submodelElements: [prop2.toPlain()] });
   });
 
+  it("should copy values readable by specified subject", () => {
+    const security = Security.create({});
+    const submodel = Submodel.create({ idShort: "section1" });
+
+    const anonymous = SubjectAttributes.create({ userRole: UserRole.ANONYMOUS });
+    security.addPolicy(
+      member,
+      IdShortPath.create({ path: "section1" }),
+      [Permission.create({ permission: Permissions.Read, kindOfPermission: PermissionKind.Allow }), Permission.create({ permission: Permissions.Create, kindOfPermission: PermissionKind.Allow })],
+    );
+    security.addPolicy(member, IdShortPath.create({ path: "section1.prop1" }), [Permission.create({ permission: Permissions.Read, kindOfPermission: PermissionKind.Allow })]);
+    security.addPolicy(member, IdShortPath.create({ path: "section1.prop2" }), []);
+    let ability = security.defineAbilityForSubject(member);
+
+    const prop1 = Property.create({ idShort: "prop1", value: "10", valueType: DataTypeDef.Double });
+    const prop2 = Property.create({ idShort: "prop2", value: "10", valueType: DataTypeDef.Double });
+    submodel.addSubmodelElement(prop1, { ability });
+    submodel.addSubmodelElement(prop2, { ability });
+
+    expect(submodel.copy({ ability }).submodelElements).toEqual([prop1]);
+    ability = security.defineAbilityForSubject(anonymous);
+    expect(submodel.copy({ ability })).toEqual(undefined);
+    security.addPolicy(anonymous, IdShortPath.create({ path: "section1.prop2" }), [Permission.create({ permission: Permissions.Read, kindOfPermission: PermissionKind.Allow })]);
+    ability = security.defineAbilityForSubject(anonymous);
+    expect(submodel.copy({ ability }).submodelElements).toEqual([prop2]);
+  });
+
   it("should get value representation for bill of material", () => {
     const iriDomain = `http://open-dpp.de/${randomUUID()}`;
     const member = SubjectAttributes.create({ userRole: UserRole.USER, memberRole: MemberRole.MEMBER });

--- a/apps/main/src/aas/domain/submodel-base/submodel.ts
+++ b/apps/main/src/aas/domain/submodel-base/submodel.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import { NotFoundException } from "@nestjs/common";
 import { KeyTypes, ModellingKindType, ReferenceTypes, SubmodelJsonSchema } from "@open-dpp/dto";
 import { ValueError } from "@open-dpp/exception";
+import { isEmptyObject } from "../../../utils";
 import { AdministrativeInformation } from "../common/administrative-information";
 import { IdShortPath } from "../common/id-short-path";
 import { Key } from "../common/key";
@@ -9,6 +10,7 @@ import { hasUniqueLanguagesOrFail, LanguageText } from "../common/language-text"
 import { Qualifier } from "../common/qualififiable";
 import { Reference } from "../common/reference";
 import { ConvertToPlainOptions } from "../convertable-to-plain";
+import { ICopyOptions } from "../copy-options";
 import { EmbeddedDataSpecification } from "../embedded-data-specification";
 import { Extension } from "../extension";
 import JsonVisitor from "../json-visitor";
@@ -247,9 +249,13 @@ export class Submodel implements ISubmodelBase, IPersistable {
     return this.submodelElements;
   }
 
-  copy(): Submodel {
+  copy(options?: ICopyOptions): Submodel | undefined {
+    const plain = this.toPlain(options);
+    if (isEmptyObject(plain)) {
+      return undefined;
+    }
     return Submodel.fromPlain({
-      ...this.toPlain(),
+      ...plain,
       id: randomUUID(),
     });
   }

--- a/apps/main/src/aas/presentation/environment.service.spec.ts
+++ b/apps/main/src/aas/presentation/environment.service.spec.ts
@@ -412,6 +412,20 @@ describe("environmentService", () => {
     ).rejects.toThrow(new ForbiddenError("Missing permissions to modify element section1.subSection1.property1."));
   });
 
+  it("should copy environment", async () => {
+    const { environment, admin } = await createDefaultEnvironment();
+    const copy = await environmentService.copyEnvironment(
+      environment,
+      admin,
+    );
+
+    expect(copy.submodels).toHaveLength(1);
+    //
+    const anonymous = SubjectAttributes.create({ userRole: UserRole.ANONYMOUS });
+    const anonymousCopy = await environmentService.copyEnvironment(environment, anonymous);
+    expect(anonymousCopy.submodels).toHaveLength(0);
+  });
+
   async function createEnvironmentWithList() {
     const security = Security.create({});
     const admin = SubjectAttributes.create({ userRole: UserRole.ADMIN });

--- a/apps/main/src/aas/presentation/environment.service.ts
+++ b/apps/main/src/aas/presentation/environment.service.ts
@@ -450,13 +450,28 @@ export class EnvironmentService {
     return PagingResult.create({ pagination: pagingResult.pagination, items: populatedItems });
   }
 
-  async copyEnvironment(environment: Environment): Promise<Environment> {
-    const submodelsCopy = await Promise.all(environment.submodels.map(async modelId => (await this.findSubmodelByIdOrFail(environment, modelId)).copy()));
+  async copyEnvironment(environment: Environment, subject: SubjectAttributes): Promise<Environment> {
+    const ability = await this.loadAbility(environment, subject);
+
+    const submodelsCopy: Submodel[] = [];
+    for (const submodelId of environment.submodels) {
+      const submodel = await this.findSubmodelByIdOrFail(environment, submodelId);
+      const copy = submodel.copy({ ability });
+      if (copy) {
+        submodelsCopy.push(copy);
+      }
+    }
     const aasCopy = (await this.getFirstAssetAdministrationShell(environment)).copy(submodelsCopy);
-
-    await this.aasRepository.save(aasCopy);
-    await Promise.all(submodelsCopy.map(model => this.submodelRepository.save(model)));
-
+    const session = await this.connection.startSession();
+    try {
+      await session.withTransaction(async () => {
+        await this.aasRepository.save(aasCopy);
+        await Promise.all(submodelsCopy.map(model => this.submodelRepository.save(model)));
+      });
+    }
+    finally {
+      await session.endSession();
+    }
     return Environment.create({
       assetAdministrationShells: [aasCopy.id],
       submodels: submodelsCopy.map(model => model.id),

--- a/apps/main/src/passports/presentation/passport.controller.ts
+++ b/apps/main/src/passports/presentation/passport.controller.ts
@@ -181,7 +181,7 @@ export class PassportController implements IAasReadEndpointsWithOrganizationId, 
       { templateId: P.string },
       async ({ templateId }) => {
         const template = await this.loadTemplateAndCheckOwnership(templateId, subject, organizationId);
-        return { environment: await this.environmentService.copyEnvironment(template.environment), templateId };
+        return { environment: await this.environmentService.copyEnvironment(template.environment, subject), templateId };
       },
     ).with({
       environment: { assetAdministrationShells: P.array() },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Copy operations now respect user access permissions—only elements and submodels the user can read are copied.

* **Bug Fixes**
  * Fixed operation sequencing during submodel creation to refresh data before updating the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->