### PR TITLE
Fix docker image tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -170,7 +170,7 @@ jobs:
           tags: |
             type=sha
             type=ref,event=branch
-            type=ref,event=tag
+            type=semver,pattern={{version}}
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
 
       - name: Build and push by digest
@@ -236,7 +236,7 @@ jobs:
           tags: |
             type=sha
             type=ref,event=branch
-            type=ref,event=tag
+            type=semver,pattern={{version}}
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
 
       - name: Create manifest list and push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,15 +42,20 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      # Push a repo-wide `v<version>` git tag so `build.yml` (which triggers
-      # on `tags: ["v*"]`) rebuilds the Docker image with a version-numbered
-      # tag. Every `@open-dpp/*` package is in the `fixed` group in
-      # `.changeset/config.json`, so the first published package carries the
-      # canonical release version for the whole repo.
+      # Push a repo-wide `v<version>` git tag so the release is reachable by
+      # tag name in git. Every `@open-dpp/*` package is in the `fixed` group
+      # in `.changeset/config.json`, so the first published package carries
+      # the canonical release version for the whole repo.
+      #
+      # Note: this tag push is made with `GITHUB_TOKEN`, which (by design)
+      # does not trigger other workflow runs. That's why the next step
+      # explicitly dispatches `build.yml` with the tag as its ref — it would
+      # otherwise never run for the versioned Docker image.
       #
       # PUBLISHED_PACKAGES is passed through an env var (not inlined via
       # ${{ }}) to avoid script injection via workflow expression expansion.
-      - name: Push repo-wide version tag for Docker
+      - name: Push repo-wide version tag
+        id: version-tag
         if: steps.changesets.outputs.published == 'true'
         env:
           PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
@@ -62,9 +67,23 @@ jobs:
             exit 1
           fi
           tag="v$version"
-          if git rev-parse -q --verify "refs/tags/$tag" >/dev/null; then
-            echo "Tag $tag already exists, skipping."
-            exit 0
+          if ! git rev-parse -q --verify "refs/tags/$tag" >/dev/null; then
+            git tag "$tag"
+            git push origin "$tag"
+          else
+            echo "Tag $tag already exists, skipping push."
           fi
-          git tag "$tag"
-          git push origin "$tag"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+      # Trigger `build.yml` at the tag ref so `docker/metadata-action` picks
+      # up the tag via `type=semver,pattern={{version}}` and publishes a
+      # version-tagged Docker image. RELEASE_TAG is read from the previous
+      # step's output via env var to avoid inlining `${{ }}` into `run:`.
+      - name: Trigger versioned Docker build
+        if: steps.changesets.outputs.published == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ steps.version-tag.outputs.tag }}
+        run: |
+          set -euo pipefail
+          gh workflow run build.yml --repo "$GITHUB_REPOSITORY" --ref "$RELEASE_TAG"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,14 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: release
+  cancel-in-progress: false
+
 permissions:
   contents: write
   pull-requests: write
+  actions: write
 
 env:
   NODE_VERSION: 24
@@ -67,11 +72,17 @@ jobs:
             exit 1
           fi
           tag="v$version"
-          if ! git rev-parse -q --verify "refs/tags/$tag" >/dev/null; then
+          git fetch origin --tags --force
+          if git rev-parse -q --verify "refs/tags/$tag" >/dev/null; then
+            existing_sha=$(git rev-parse "refs/tags/$tag^{commit}")
+            if [ "$existing_sha" != "$GITHUB_SHA" ]; then
+              echo "Tag $tag already exists at $existing_sha (expected $GITHUB_SHA)" >&2
+              exit 1
+            fi
+            echo "Tag $tag already exists at $GITHUB_SHA, skipping push."
+          else
             git tag "$tag"
             git push origin "$tag"
-          else
-            echo "Tag $tag already exists, skipping push."
           fi
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -172,7 +172,7 @@ Both secrets are configured on the `open-dpp/open-dpp` repository:
 | Secret         | Purpose                                                                                                                    |
 | -------------- | -------------------------------------------------------------------------------------------------------------------------- |
 | `NPM_TOKEN`    | npm automation token with publish rights to the `@open-dpp` scope. Consumed by `pnpm release` / `changeset publish`.       |
-| `GITHUB_TOKEN` | Provided automatically by Actions. Requires `contents: write` and `pull-requests: write`, already set in `release.yml`.    |
+| `GITHUB_TOKEN` | Provided automatically by Actions. Requires `contents: write`, `pull-requests: write`, and `actions: write` (for dispatching `build.yml` at the release tag), already set in `release.yml`. |
 
 If `NPM_TOKEN` is missing or expired, the `Release` job will fail at the publish step. Rotate the token in npm, update the GitHub secret, and re-run the failed job.
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -31,9 +31,9 @@ flowchart TD
     L --> M[Publish @open-dpp/api-client<br/>+ @open-dpp/dto to npm]
     L --> N[Create local git tags<br/>@open-dpp/api-client@X.Y.Z<br/>@open-dpp/dto@X.Y.Z]
     N --> O[changesets/action<br/>pushes tag to origin]
-    O --> P[Post-publish step:<br/>push repo-wide vX.Y.Z tag]
-    P --> Q[build.yml runs on tag push]
-    Q --> R[Publish ghcr.io/open-dpp/open-dpp:X.Y.Z]
+    O --> P[Push repo-wide vX.Y.Z tag<br/>post-publish step]
+    P --> Q[Dispatch build.yml at tag ref<br/>post-publish step]
+    Q --> R[build.yml publishes<br/>ghcr.io/open-dpp/open-dpp:X.Y.Z]
 ```
 
 ## When you need a changeset
@@ -113,7 +113,8 @@ sequenceDiagram
     WF->>WF: Create local tags<br/>@open-dpp/api-client@X.Y.Z<br/>@open-dpp/dto@X.Y.Z
     CS->>GH: Push new tag to origin
     WF->>GH: Push repo-wide vX.Y.Z tag<br/>(post-publish step)
-    GH->>WF: Trigger build.yml on tag push
+    WF->>GH: Dispatch build.yml at vX.Y.Z ref<br/>(post-publish step)
+    GH->>WF: Run build.yml via workflow_dispatch
     WF->>GHCR: Publish ghcr.io/open-dpp/open-dpp:X.Y.Z
 ```
 
@@ -139,12 +140,12 @@ sequenceDiagram
 
 The npm release flow and the Docker build flow ([`build.yml`](./.github/workflows/build.yml)) are **independent workflows** triggered from the same commits. `build.yml` runs on every push to `main` (and on every PR to `main`) and publishes multi-arch images to `ghcr.io/open-dpp/open-dpp` with tags `:latest`, `:main`, and `:sha-<short-sha>`.
 
-To give each Changesets release a corresponding version-tagged Docker image (e.g. `:0.2.0`), `release.yml` has a post-publish step that:
+To give each Changesets release a corresponding version-tagged Docker image (e.g. `:0.2.0`), `release.yml` has two post-publish steps that:
 
-1. Reads the released version from `changesets/action`'s `publishedPackages` output.
-2. Creates and pushes a repo-wide `v<version>` git tag (e.g. `v0.2.0`).
+1. Read the released version from `changesets/action`'s `publishedPackages` output and push a repo-wide `v<version>` git tag (e.g. `v0.2.0`).
+2. Dispatch `build.yml` via `gh workflow run build.yml --ref v<version>`. This triggers a second `build.yml` run with `github.ref = refs/tags/v<version>`, so `docker/metadata-action` picks up the ref via `type=semver,pattern={{version}}` and publishes the image as `ghcr.io/open-dpp/open-dpp:<version>`. The image is built from exactly the same commit as `:latest`, so `:latest` and `:<version>` always point at the same digest at release time.
 
-This tag push triggers `build.yml` a second time via its `on.push.tags: ["v*"]` filter. `docker/metadata-action` picks up the tag via `type=ref,event=tag` and publishes the image as `ghcr.io/open-dpp/open-dpp:<version>`. The image is built from exactly the same commit as `:latest`, so `:latest` and `:<version>` always point at the same digest at release time.
+> **Why the explicit dispatch?** The tag push alone would not trigger `build.yml`. Pushes made by `GITHUB_TOKEN` (including the `git push origin v<version>` in the post-publish step) are, by design, prevented from triggering other workflow runs. Dispatching `build.yml` via the GitHub API (`gh workflow run`) bypasses that restriction. The `tags: ["v*"]` filter on `build.yml` is still honored for **manual / local** tag pushes (see escape hatch below), which are made with a human token rather than `GITHUB_TOKEN`.
 
 **Tag shapes you will see after a release:**
 
@@ -152,8 +153,8 @@ This tag push triggers `build.yml` a second time via its `on.push.tags: ["v*"]` 
 | ------------------------------------ | -------------------------------- | -------------------------------------------------------- |
 | `@open-dpp/api-client@<version>`     | `changeset publish`              | Per-package git tag for the published npm package.       |
 | `@open-dpp/dto@<version>`            | `changeset publish`              | Per-package git tag for the published npm package.       |
-| `v<version>`                         | `release.yml` post-publish step  | Repo-wide git tag; drives version-tagged Docker builds.  |
-| Docker `:<version>`                  | `build.yml` (triggered by `v*`)  | Pinnable Docker image for the release.                   |
+| `v<version>`                         | `release.yml` post-publish step  | Repo-wide git reference for the release; used as the ref of the dispatched `build.yml` run. |
+| Docker `:<version>`                  | `build.yml` (dispatched at `v<version>` ref) | Pinnable Docker image for the release.                                                      |
 | Docker `:latest`, `:main`, `:sha-*`  | `build.yml` (every push to main) | Rolling tags; unchanged by this flow.                    |
 
 If you run the **manual / local release** escape hatch, remember to create the `v<version>` tag yourself after `pnpm release`:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2423,27 +2423,6 @@ packages:
   '@one-ini/wasm@0.1.1':
     resolution: {integrity: sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==}
 
-  '@open-dpp/api-client@file:packages/api-client':
-    resolution: {directory: packages/api-client, type: directory}
-
-  '@open-dpp/config-eslint@file:packages/config-eslint':
-    resolution: {directory: packages/config-eslint, type: directory}
-
-  '@open-dpp/dto@file:packages/dto':
-    resolution: {directory: packages/dto, type: directory}
-
-  '@open-dpp/env@file:packages/env':
-    resolution: {directory: packages/env, type: directory}
-
-  '@open-dpp/exception@file:packages/exception':
-    resolution: {directory: packages/exception, type: directory}
-
-  '@open-dpp/permission@file:packages/permission':
-    resolution: {directory: packages/permission, type: directory}
-
-  '@open-dpp/testing@file:packages/testing':
-    resolution: {directory: packages/testing, type: directory}
-
   '@open-draft/deferred-promise@2.2.0':
     resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
 
@@ -10921,75 +10900,6 @@ snapshots:
       consola: 3.4.2
 
   '@one-ini/wasm@0.1.1': {}
-
-  '@open-dpp/api-client@file:packages/api-client':
-    dependencies:
-      '@open-dpp/dto': file:packages/dto
-      axios: 1.13.4
-    transitivePeerDependencies:
-      - debug
-
-  '@open-dpp/config-eslint@file:packages/config-eslint': {}
-
-  '@open-dpp/dto@file:packages/dto':
-    dependencies:
-      uuid: 13.0.0
-      zod: 4.3.6
-
-  '@open-dpp/env@file:packages/env(@nestjs/microservices@11.1.13)(@nestjs/platform-express@11.1.13)(@nestjs/websockets@11.1.13)(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)':
-    dependencies:
-      '@nestjs/common': 11.1.13(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      '@nestjs/config': 4.0.3(@nestjs/common@11.1.13(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(rxjs@7.8.2)
-      '@nestjs/core': 11.1.13(@nestjs/common@11.1.13(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/microservices@11.1.13)(@nestjs/platform-express@11.1.13)(@nestjs/websockets@11.1.13)(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      zod: 4.3.6
-    transitivePeerDependencies:
-      - '@nestjs/microservices'
-      - '@nestjs/platform-express'
-      - '@nestjs/websockets'
-      - class-transformer
-      - class-validator
-      - reflect-metadata
-      - rxjs
-      - supports-color
-
-  '@open-dpp/exception@file:packages/exception(@nestjs/microservices@11.1.13)(@nestjs/platform-express@11.1.13)(@nestjs/websockets@11.1.13)(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)':
-    dependencies:
-      '@nestjs/common': 11.1.13(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      '@nestjs/core': 11.1.13(@nestjs/common@11.1.13(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/microservices@11.1.13)(@nestjs/platform-express@11.1.13)(@nestjs/websockets@11.1.13)(reflect-metadata@0.2.2)(rxjs@7.8.2)
-    transitivePeerDependencies:
-      - '@nestjs/microservices'
-      - '@nestjs/platform-express'
-      - '@nestjs/websockets'
-      - class-transformer
-      - class-validator
-      - reflect-metadata
-      - rxjs
-      - supports-color
-
-  '@open-dpp/permission@file:packages/permission':
-    dependencies:
-      '@casl/ability': 6.8.0
-
-  '@open-dpp/testing@file:packages/testing(@nestjs/microservices@11.1.13)(@nestjs/platform-express@11.1.13)(@nestjs/websockets@11.1.13)(class-validator@0.14.3)(mongoose@9.1.6)(reflect-metadata@0.2.2)(rxjs@7.8.2)':
-    dependencies:
-      '@nestjs/common': 11.1.13(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      '@nestjs/config': 4.0.3(@nestjs/common@11.1.13(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(rxjs@7.8.2)
-      '@nestjs/core': 11.1.13(@nestjs/common@11.1.13(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/microservices@11.1.13)(@nestjs/platform-express@11.1.13)(@nestjs/websockets@11.1.13)(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      '@nestjs/mongoose': 11.0.4(@nestjs/common@11.1.13(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.13)(mongoose@9.1.6)(rxjs@7.8.2)
-      '@open-dpp/dto': file:packages/dto
-      '@open-dpp/env': file:packages/env(@nestjs/microservices@11.1.13)(@nestjs/platform-express@11.1.13)(@nestjs/websockets@11.1.13)(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      class-transformer: 0.5.1
-      fishery: 2.4.0
-      zod: 4.3.6
-    transitivePeerDependencies:
-      - '@nestjs/microservices'
-      - '@nestjs/platform-express'
-      - '@nestjs/websockets'
-      - class-validator
-      - mongoose
-      - reflect-metadata
-      - rxjs
-      - supports-color
 
   '@open-draft/deferred-promise@2.2.0': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,4 @@
 packages:
-  - apps/*/*
   - apps/*
   - packages/*
   - docs


### PR DESCRIPTION
This pull request updates the release automation workflow to ensure that Docker images are correctly tagged with semantic versions after each release, addressing a GitHub Actions limitation where workflow runs triggered by the repository's `GITHUB_TOKEN` do not trigger downstream workflows. The process now explicitly dispatches the Docker build workflow after pushing a release tag, and updates documentation to reflect this improved flow. Additionally, Docker image tagging in the build workflow is updated to use semantic versioning.

Workflow improvements:

* The `release.yml` workflow now explicitly dispatches the `build.yml` workflow after pushing the `v<version>` tag, ensuring that a version-tagged Docker image is published even though `GITHUB_TOKEN`-triggered tag pushes do not trigger workflows automatically. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L45-R58) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L65-R89)

Docker image tagging:

* The `build.yml` workflow updates Docker image tagging to use `type=semver,pattern={{version}}` instead of `type=ref,event=tag`, aligning with the explicit workflow dispatch and semantic versioning best practices. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L173-R173) [[2]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L239-R239)

Documentation updates:

* The release flow diagrams and documentation in `RELEASING.md` are updated to describe the new two-step post-publish process: pushing the `v<version>` tag and then dispatching the Docker build workflow. This clarifies why the explicit dispatch is required and how Docker images are tagged. [[1]](diffhunk://#diff-87d6a57a759f2386bf9caf5309b9aa0b9ff0ca70f5e38696e114a1ccdb0e785dL34-R36) [[2]](diffhunk://#diff-87d6a57a759f2386bf9caf5309b9aa0b9ff0ca70f5e38696e114a1ccdb0e785dL116-R117) [[3]](diffhunk://#diff-87d6a57a759f2386bf9caf5309b9aa0b9ff0ca70f5e38696e114a1ccdb0e785dL142-R157)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow to use semantic versioning for Docker image tags instead of git tag refs.
  * Enhanced release process to explicitly trigger Docker builds via workflow dispatch, improving build consistency.

* **Documentation**
  * Updated release documentation to reflect the new release-to-Docker pipeline with explicit workflow dispatch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->