### PR TITLE
Switch API docs to Swagger, update OpenAPI paths with parameter syntax, and add URL example fixes.

### DIFF
--- a/.changeset/odd-schools-lay.md
+++ b/.changeset/odd-schools-lay.md
@@ -1,0 +1,14 @@
+---
+"@open-dpp/api-client": minor
+"@open-dpp/permission": minor
+"@open-dpp/exception": minor
+"@open-dpp/testing": minor
+"@open-dpp/dto": minor
+"@open-dpp/env": minor
+"@open-dpp/client": minor
+"@open-dpp/main": minor
+"e2e": minor
+"@open-dpp/docs": minor
+---
+
+Use swagger documentation instead of vitest open api documentation. Correct parameter syntax in open api documentation from :id to {id}.

--- a/apps/main/src/aas/presentation/aas.decorators.ts
+++ b/apps/main/src/aas/presentation/aas.decorators.ts
@@ -234,7 +234,6 @@ export const CursorQueryParamSchema = z
   .meta({
     description:
       "A server-generated identifier retrieved from pagingMetadata that specifies from which position the result listing should continue",
-    example: "958b741c-c2ef-4366-a134-fafd30210ed4 ",
     param: { in: "query", name: "cursor" },
   });
 

--- a/apps/main/src/open-api-docs/aas.paths.ts
+++ b/apps/main/src/open-api-docs/aas.paths.ts
@@ -50,13 +50,14 @@ import {
 } from "../digital-product-document/presentation/digital-product-document-decorators";
 import { HTTPCode } from "./http.codes";
 import { ContentType } from "./content.types";
+import { convertPathToOpenApi } from "./utils";
 
 const security = [{ apiKeyAuth: [] }];
 const orgaIdHeader = { $ref: "#/components/parameters/OrganizationIdHeader" };
 
 export function createAasPaths(tag: string) {
   return {
-    [`/${tag}${ApiGetShellsPath}`]: {
+    [`/${tag}${convertPathToOpenApi(ApiGetShellsPath)}`]: {
       get: {
         tags: [tag],
         summary: "Returns all Asset Administration Shells",
@@ -71,7 +72,7 @@ export function createAasPaths(tag: string) {
         security,
       },
     },
-    [`/${tag}${ApiPatchShellPath}`]: {
+    [`/${tag}${convertPathToOpenApi(ApiPatchShellPath)}`]: {
       patch: {
         tags: [tag],
         summary: "Modifies a Asset Administration Shell with specified id",
@@ -91,7 +92,7 @@ export function createAasPaths(tag: string) {
         security,
       },
     },
-    [`/${tag}${ApiSubmodelsPath}`]: {
+    [`/${tag}${convertPathToOpenApi(ApiSubmodelsPath)}`]: {
       get: {
         tags: [tag],
         summary: `Returns all Submodels of the ${tag}`,
@@ -125,7 +126,7 @@ export function createAasPaths(tag: string) {
         security,
       },
     },
-    [`/${tag}${ApiGetSubmodelByIdPath}`]: {
+    [`/${tag}${convertPathToOpenApi(ApiGetSubmodelByIdPath)}`]: {
       get: {
         tags: [tag],
         summary: `Returns Submodel by id`,
@@ -168,7 +169,7 @@ export function createAasPaths(tag: string) {
         security,
       },
     },
-    [`/${tag}${ApiGetSubmodelValuePath}`]: {
+    [`/${tag}${convertPathToOpenApi(ApiGetSubmodelValuePath)}`]: {
       patch: {
         operationId: "patchValueOfSubmodel",
         tags: [tag],
@@ -202,7 +203,7 @@ export function createAasPaths(tag: string) {
         security,
       },
     },
-    [`/${tag}${ApiSubmodelElementsPath}`]: {
+    [`/${tag}${convertPathToOpenApi(ApiSubmodelElementsPath)}`]: {
       get: {
         tags: [tag],
         summary: `Returns all Submodel Elements of the given Submodel`,
@@ -241,7 +242,7 @@ export function createAasPaths(tag: string) {
         security,
       },
     },
-    [`/${tag}${ApiPostColumnPath}`]: {
+    [`/${tag}${convertPathToOpenApi(ApiPostColumnPath)}`]: {
       post: {
         tags: [tag],
         summary: `Add column to Submodel Element List with specified idShortPath. Column is itself a Submodel Element.`,
@@ -267,7 +268,7 @@ export function createAasPaths(tag: string) {
         security,
       },
     },
-    [`/${tag}${ApiGetColumnByIdShortPath}`]: {
+    [`/${tag}${convertPathToOpenApi(ApiGetColumnByIdShortPath)}`]: {
       delete: {
         tags: [tag],
         summary:
@@ -314,7 +315,7 @@ export function createAasPaths(tag: string) {
         security,
       },
     },
-    [`/${tag}${ApiPostRowPath}`]: {
+    [`/${tag}${convertPathToOpenApi(ApiPostRowPath)}`]: {
       post: {
         tags: [tag],
         summary: `Add row to Submodel Element List with specified idShortPath.`,
@@ -335,7 +336,7 @@ export function createAasPaths(tag: string) {
         security,
       },
     },
-    [`/${tag}${ApiDeletePolicyPath}`]: {
+    [`/${tag}${convertPathToOpenApi(ApiDeletePolicyPath)}`]: {
       delete: {
         tags: [tag],
         summary: `Deletes policy for specified subject and object.`,
@@ -351,7 +352,7 @@ export function createAasPaths(tag: string) {
         security,
       },
     },
-    [`/${tag}${ApiDeleteRowPath}`]: {
+    [`/${tag}${convertPathToOpenApi(ApiDeleteRowPath)}`]: {
       delete: {
         tags: [tag],
         summary: `Deletes row with specified idShort from Submodel Element List with specified idShortPath.`,
@@ -372,7 +373,7 @@ export function createAasPaths(tag: string) {
         security,
       },
     },
-    [`/${tag}${ApiGetSubmodelElementByIdPath}`]: {
+    [`/${tag}${convertPathToOpenApi(ApiGetSubmodelElementByIdPath)}`]: {
       get: {
         tags: [tag],
         summary: `Returns Submodel Element by idShortPath`,
@@ -432,7 +433,7 @@ export function createAasPaths(tag: string) {
         security,
       },
     },
-    [`/${tag}${ApiGetSubmodelElementValuePath}`]: {
+    [`/${tag}${convertPathToOpenApi(ApiGetSubmodelElementValuePath)}`]: {
       get: {
         tags: [tag],
         summary: `Returns value representation of Submodel Element`,

--- a/apps/main/src/open-api-docs/index.ts
+++ b/apps/main/src/open-api-docs/index.ts
@@ -41,6 +41,7 @@ const document = createDocument({
         schema: {
           type: "string",
         },
+        example: "690cf22459cdae7ce188c1f8",
         description: "Organization identifier",
       },
     },
@@ -60,5 +61,5 @@ export function buildOpenApiDocumentation(): OpenAPIObject {
 }
 
 export function addSwaggerToApp(app: INestApplication, openApiDoc: OpenAPIObject) {
-  SwaggerModule.setup("api", app, openApiDoc);
+  SwaggerModule.setup("api", app, openApiDoc, { jsonDocumentUrl: "api.json" });
 }

--- a/apps/main/src/open-api-docs/utils.spec.ts
+++ b/apps/main/src/open-api-docs/utils.spec.ts
@@ -1,0 +1,7 @@
+import { convertPathToOpenApi } from "./utils";
+
+it("should convert to open api path", () => {
+  expect(convertPathToOpenApi("passports/:id/submodels/:submodelId/submodelElements")).toEqual(
+    "passports/{id}/submodels/{submodelId}/submodelElements",
+  );
+});

--- a/apps/main/src/open-api-docs/utils.ts
+++ b/apps/main/src/open-api-docs/utils.ts
@@ -1,0 +1,3 @@
+export function convertPathToOpenApi(path: string) {
+  return path.replace(/:([A-Za-z_][A-Za-z0-9_]*)/g, "{$1}");
+}

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -22,7 +22,7 @@ export default defineConfig({
     },
     nav: [
       { text: "Home", link: "/home" },
-      { text: "Rest API", link: "/api" },
+      { text: "Rest API", link: "https://app.cloud.open-dpp.de/api" },
       {
         text: `v${pkg.version}`,
         link: "https://github.com/open-dpp/open-dpp/releases",

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,5 +14,8 @@ hero:
       link: /home/about
     - theme: alt
       text: Open-API v3 Documentation
-      link: /api
+      link: https://app.cloud.open-dpp.de/api
+    - theme: alt
+      text: Download Open-API v3 Documentation
+      link: https://app.cloud.open-dpp.de/api.json
 ---


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API documentation guidance to use Swagger/OpenAPI v3 format
  * API documentation links now point to Cloud environment
  * Corrected OpenAPI parameter syntax formatting to standard format

* **Releases**
  * Multiple core packages updated to minor versions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/open-dpp/open-dpp/pull/575)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->