### PR TITLE
fix: update API URLs in documentation to remove 'app.' prefix

### DIFF
--- a/apps/main/src/open-api-docs/index.ts
+++ b/apps/main/src/open-api-docs/index.ts
@@ -14,11 +14,11 @@ const document = createDocument({
   },
   servers: [
     {
-      url: "https://app.cloud.open-dpp.de/api",
+      url: "https://cloud.open-dpp.de/api",
       description: "Production server",
     },
     {
-      url: "https://app.demo1.open-dpp.de/api",
+      url: "https://demo.open-dpp.de/api",
       description: "Test server",
     },
     {

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -22,7 +22,7 @@ export default defineConfig({
     },
     nav: [
       { text: "Home", link: "/home" },
-      { text: "Rest API", link: "https://app.cloud.open-dpp.de/api" },
+      { text: "Rest API", link: "https://cloud.open-dpp.de/api" },
       {
         text: `v${pkg.version}`,
         link: "https://github.com/open-dpp/open-dpp/releases",

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,8 +14,8 @@ hero:
       link: /home/about
     - theme: alt
       text: Open-API v3 Documentation
-      link: https://app.cloud.open-dpp.de/api
+      link: https://cloud.open-dpp.de/api
     - theme: alt
       text: Download Open-API v3 Documentation
-      link: https://app.cloud.open-dpp.de/api.json
+      link: https://cloud.open-dpp.de/api.json
 ---


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated API endpoint base URLs to streamlined domain structure (`cloud.open-dpp.de` and `demo.open-dpp.de`)
  * Updated documentation navigation and links to reference new API endpoint locations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/open-dpp/open-dpp/pull/577)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->