### PR TITLE
docs: fix local dev setup — MongoDB keyfile, package build, make/dotenvx

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,13 +62,34 @@ pnpm install
 cp .env.dev.example .env.dev
 ```
 
-Set required secrets and API keys in `.env.dev`.
+Set required secrets and API keys in `.env.dev`. The `dev` and `test` scripts also load an optional `.env` file for local overrides; create an empty one with `touch .env` to silence a harmless "missing file" warning if you have no overrides.
+
+### Generate the MongoDB keyfile
+
+Local MongoDB runs as a single-node replica set (required for the multi-document transactions the backend uses), which needs a shared keyfile. This file is intentionally not committed, so generate it once before starting the infrastructure:
+
+```bash
+openssl rand -base64 756 > docker/mongo_keyfile
+chmod 600 docker/mongo_keyfile
+```
+
+The `chmod 600` is required — MongoDB refuses to start if the keyfile is group- or world-readable.
+
+### Build shared packages
+
+The apps import the shared `packages/*` from their compiled `dist/` output, and `pnpm run dev` does not build the packages automatically. Build them once before the first run (and again after changing a package):
+
+```bash
+pnpm run build
+```
 
 ### Start local infrastructure
 
 ```bash
-make dev
+pnpm exec make dev
 ```
+
+This starts MongoDB, MinIO, Mailpit, and ClamAV via Docker Compose. Run it with `pnpm exec` so the local `dotenvx` CLI is found on your `PATH`; plain `make dev` only works if `dotenvx` is installed globally.
 
 ### Run the application
 
@@ -79,7 +100,7 @@ pnpm run dev
 Useful URLs after startup:
 
 - App: `http://localhost:3000`
-- Mailpit: `http://localhost:8025`
+- Mailpit: `http://localhost:8025` — open this to confirm your sign-up email and verify your account.
 
 ## Quality checks
 


### PR DESCRIPTION
## What & why

Following `CONTRIBUTING.md` on a fresh clone currently fails at three points before the app will start. This PR documents the missing steps in the **Development setup** section so a new contributor can go from clone to a running app without debugging.

**1. The MongoDB keyfile is never generated.**
`docker-compose.dev.yml` starts Mongo as a replica set with `--keyFile /etc/mongo/mongo_keyfile`, but `docker/mongo_keyfile` is gitignored and nothing creates it. On a fresh clone the bind mount auto-creates an empty *directory*, and Mongo crash-loops with:

```
permissions on /etc/mongo/mongo_keyfile are too open
Error creating service context :: Unable to acquire security key[s]
```

`openssl` is already listed as a prerequisite, which suggests this step was intended. Added a step to generate the keyfile with `openssl rand -base64 756` + `chmod 600`.

**2. Shared packages aren't built before `pnpm run dev`.**
The `packages/*` are consumed from their compiled `dist/`, but they have no `dev` script and the `turbo` `dev` task has no `dependsOn: ["^build"]`, so `pnpm run dev` never builds them. The backend exits at startup with:

```
Error: Cannot find module '.../apps/main/node_modules/@open-dpp/env/dist/index.js'
```

Added a `pnpm run build` step before the first run.

**3. `make dev` can't find `dotenvx`.**
The `dev` target calls the bare `dotenvx` binary, which is a local dependency (`node_modules/.bin`), not global. `make` doesn't put the local bin on `PATH` (only `pnpm` does), so `make dev` fails with `make: dotenvx: No such file or directory`. Documented `pnpm exec make dev`.

Also: a small note that `.env` is optional (the `-f .env` load is non-fatal if absent), and a pointer that sign-up verification emails land in Mailpit.

## Notes for maintainers

Docs-only, existing structure/style preserved. Some of these could alternatively be fixed in code if you'd prefer — e.g. have the `Makefile` call `pnpm exec dotenvx`/`npx`, or add a `setup`/`predev` script that generates the keyfile and runs the package build. Happy to follow up with that.

## Testing

Followed the updated steps end-to-end on macOS (Docker Desktop, Node 22, pnpm 10): infra came up, the Mongo replica set initialized, the backend booted on `:3000` and served the app, Vite on `:5173`, Mailpit on `:8025`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated local development setup with clearer environment configuration guidance
  * Added MongoDB keyfile generation step including required permissions
  * Clarified shared package build process before starting local infrastructure
  * Enhanced Mailpit documentation for testing sign-up email verification workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->