### PR TITLE
feat(media): key public media on permalinks; harden media access (3/3)

### DIFF
--- a/apps/client/src/components/media/MediaFieldView.vue
+++ b/apps/client/src/components/media/MediaFieldView.vue
@@ -5,20 +5,20 @@ import { useI18n } from "vue-i18n";
 import { useMediaFile } from "../../composables/media-file.ts";
 import MediaPreview from "./MediaPreview.vue";
 
-const props = defineProps<{ mediaId: string }>();
+const props = defineProps<{ mediaId: string; permalinkIdOrSlug?: string }>();
 const { t } = useI18n();
 
 const { download, mediaInfo, fileUrl } = useMediaFile();
 
 onMounted(async () => {
-  await download(props.mediaId);
+  await download(props.mediaId, props.permalinkIdOrSlug);
 });
 </script>
 
 <template>
   <div v-if="mediaInfo" class="flex max-w-full flex-col gap-4">
     <div class="flex w-full flex-row gap-4">
-      <MediaPreview :media="mediaInfo" class="h-40 min-w-[160px]" />
+      <MediaPreview :media="mediaInfo" :object-url="fileUrl" class="h-40 min-w-[160px]" />
       <a
         v-if="fileUrl"
         :download="mediaInfo.title"

--- a/apps/client/src/components/media/MediaPreview.vue
+++ b/apps/client/src/components/media/MediaPreview.vue
@@ -6,7 +6,7 @@ import {
   PhotoIcon,
   VideoCameraIcon,
 } from "@heroicons/vue/24/solid";
-import { onMounted, onUnmounted, ref, watch } from "vue";
+import { computed, onMounted, onUnmounted, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import { useMediaStore } from "../../stores/media";
 import RingLoader from "../navigation/RingLoader.vue";
@@ -16,20 +16,33 @@ const props = withDefaults(
     media: MediaInfo;
     showType?: boolean;
     preview?: boolean;
+    objectUrl?: string | null;
   }>(),
   { preview: true },
 );
 const { t } = useI18n();
 const mediaStore = useMediaStore();
 
-const url = ref<string | null>(null);
-const loading = ref<boolean>(true);
+// When a parent passes objectUrl (e.g. the permalink-gated MediaFieldView on the public page), use
+// it directly and never fetch by bare id — /media/:id is authenticated. The parent owns that URL's
+// lifecycle, so we must not revoke it here.
+const usesProvidedUrl = computed(() => props.objectUrl !== undefined);
+const internalUrl = ref<string | null>(null);
+const loading = ref<boolean>(!usesProvidedUrl.value);
+const url = computed(() => (usesProvidedUrl.value ? (props.objectUrl ?? null) : internalUrl.value));
 
 async function loadMedia(media: MediaInfo) {
+  if (usesProvidedUrl.value) {
+    return;
+  }
   loading.value = true;
+  if (internalUrl.value) {
+    URL.revokeObjectURL(internalUrl.value);
+    internalUrl.value = null;
+  }
   const blob = await mediaStore.downloadMedia(media.id);
   if (blob) {
-    url.value = URL.createObjectURL(blob);
+    internalUrl.value = URL.createObjectURL(blob);
   }
   loading.value = false;
 }
@@ -39,8 +52,8 @@ onMounted(async () => {
 });
 
 onUnmounted(() => {
-  if (url.value) {
-    URL.revokeObjectURL(url.value);
+  if (internalUrl.value) {
+    URL.revokeObjectURL(internalUrl.value);
   }
 });
 

--- a/apps/client/src/components/presentation/SubmodelElementValue.vue
+++ b/apps/client/src/components/presentation/SubmodelElementValue.vue
@@ -6,7 +6,9 @@ import type {
   SubmodelElementResponseDto,
 } from "@open-dpp/dto";
 import { DataTypeDef } from "@open-dpp/dto";
+import { computed } from "vue";
 import { useI18n } from "vue-i18n";
+import { useRoute } from "vue-router";
 import formatDateValueForDisplay from "../../lib/date-value.ts";
 import MediaFieldView from "../media/MediaFieldView.vue";
 import PresentationComponentRenderer from "./components/PresentationComponentRenderer.vue";
@@ -21,6 +23,9 @@ const { element, path, config } = defineProps<{
 }>();
 
 const { t } = useI18n();
+const route = useRoute();
+// Public media must be gated through the permalink (ADR 0006): access dies with the permalink.
+const permalinkIdOrSlug = computed(() => String(route.params.permalink ?? ""));
 </script>
 
 <template>
@@ -54,6 +59,7 @@ const { t } = useI18n();
     <MediaFieldView
       v-else-if="element.modelType === 'File' && typeof element.value === 'string'"
       :media-id="element.value"
+      :permalink-id-or-slug="permalinkIdOrSlug"
     />
     <List
       v-else-if="element.modelType === 'SubmodelElementList'"

--- a/apps/client/src/composables/branding.ts
+++ b/apps/client/src/composables/branding.ts
@@ -11,13 +11,11 @@ import { createObjectUrl, revokeObjectUrl } from "../lib/media";
 import { useIndexStore } from "../stores";
 import { useErrorHandlingStore } from "../stores/error.handling";
 import { HTTPCode } from "../stores/http-codes";
-import { useMediaStore } from "../stores/media";
 
 const logo = ref<MediaFile>();
 
 function useBrandingCommon(requestBranding: () => Promise<AxiosResponse<BrandingDto>>) {
   const errorHandlingStore = useErrorHandlingStore();
-  const mediaStore = useMediaStore();
   const { t } = useI18n();
 
   const cleanupMediaUrls = () => {
@@ -55,12 +53,14 @@ function useBrandingCommon(requestBranding: () => Promise<AxiosResponse<Branding
     cleanupMediaUrls();
     if (newLogo) {
       try {
-        const mediaResult = await mediaStore.fetchMedia(newLogo);
-        if (mediaResult && mediaResult.blob) {
+        // Logo bytes come from the public, ownership-gated branding route — NOT bare /media/:id,
+        // which is now authenticated. So the logo renders anonymously on the public passport page.
+        const response = await apiClient.dpp.branding.downloadLogo(newLogo);
+        const blob = response.data;
+        if (blob) {
           logo.value = {
-            blob: mediaResult.blob,
-            mediaInfo: mediaResult.mediaInfo,
-            url: createObjectUrl(mediaResult.blob),
+            blob,
+            url: createObjectUrl(blob),
           };
         }
       } catch (logoError) {

--- a/apps/client/src/composables/media-file.ts
+++ b/apps/client/src/composables/media-file.ts
@@ -9,12 +9,14 @@ export function useMediaFile() {
   const mediaStore = useMediaStore();
   const notFound = ref(false);
 
-  async function download(mediaId: string) {
+  async function download(mediaId: string, permalinkIdOrSlug?: string) {
     try {
       if (fileUrl.value) {
         URL.revokeObjectURL(fileUrl.value);
       }
-      const { blob, mediaInfo: fetchedMediaInfo } = await mediaStore.fetchMedia(mediaId);
+      const { blob, mediaInfo: fetchedMediaInfo } = permalinkIdOrSlug
+        ? await mediaStore.fetchPermalinkMedia(permalinkIdOrSlug, mediaId)
+        : await mediaStore.fetchMedia(mediaId);
 
       if (blob) {
         fileUrl.value = URL.createObjectURL(blob);

--- a/apps/client/src/lib/media.ts
+++ b/apps/client/src/lib/media.ts
@@ -10,6 +10,6 @@ export function revokeObjectUrl(url: string) {
 
 export interface MediaFile {
   blob: Blob | null;
-  mediaInfo: MediaInfo;
+  mediaInfo?: MediaInfo;
   url: string;
 }

--- a/apps/client/src/stores/media.spec.ts
+++ b/apps/client/src/stores/media.spec.ts
@@ -1,8 +1,6 @@
-import type { AxiosRequestConfig } from "axios";
 import type { MediaInfo } from "../components/media/MediaInfo.interface";
 import { createPinia, setActivePinia } from "pinia";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import apiClient from "../lib/api-client.ts";
 import { useMediaStore } from "./media";
 
 // Mocks
@@ -44,120 +42,16 @@ describe("media store", () => {
     getMock.mockReset();
   });
 
-  describe("uploadDppMedia", () => {
-    it("returns mediaId on 200/201/304 and calls progress handler", async () => {
-      const statuses = [200, 201, 304] as const;
-      for (const status of statuses) {
-        postMock.mockImplementationOnce(
-          (url: string, formData: FormData, config: AxiosRequestConfig) => {
-            // simulate upload progress
-            config?.onUploadProgress?.({ loaded: 50, total: 100 } as never);
-            return Promise.resolve({
-              status,
-              data: { mediaId: `mid-${status}` },
-            });
-          },
-        );
-        const progressCalls: number[] = [];
-        const mediaId = await apiClient.media.media.uploadDppMedia(
-          "uuid",
-          "field",
-          new File(["a"], "a.txt"),
-          (p) => progressCalls.push(p),
-        );
-        expect(mediaId).toBe(`mid-${status}`);
-        // Verify URL formatting
-        expect(postMock).toHaveBeenLastCalledWith(
-          expect.stringMatching(/\/media\/dpp\/uuid\/field$/),
-          expect.any(FormData),
-          expect.objectContaining({ onUploadProgress: expect.any(Function) }),
-        );
-        expect(progressCalls).toEqual([50]);
-      }
-    });
-
-    it("computes progress even if total is undefined (uses 1)", async () => {
-      postMock.mockImplementationOnce(
-        (url: string, formData: FormData, config: AxiosRequestConfig) => {
-          config?.onUploadProgress?.({
-            loaded: 123,
-            total: undefined,
-          } as never);
-          return Promise.resolve({ status: 200, data: { mediaId: "mid" } });
-        },
-      );
-      const progressCalls: number[] = [];
-      await apiClient.media.media.uploadDppMedia("uuid", "field", new File(["a"], "a.txt"), (p) =>
-        progressCalls.push(p),
-      );
-      expect(progressCalls).toEqual([12300]);
-    });
-
-    it("throws on unexpected status", async () => {
-      postMock.mockResolvedValueOnce({ status: 418, data: {} });
-      await expect(
-        apiClient.media.media.uploadDppMedia("uuid", "field", new File(["a"], "a.txt")),
-      ).rejects.toThrow("Unexpected upload status 418");
-    });
-  });
-
-  describe("getDppMediaInfo", () => {
-    it("throws if no uuid provided", async () => {
-      const store = useMediaStore();
-      await expect(store.getDppMediaInfo(undefined, "field")).rejects.toThrow("No UUID provided");
-    });
-
-    it("returns media info from endpoint", async () => {
-      const store = useMediaStore();
-      const info: MediaInfo = {
-        id: "",
-        title: "",
-        size: 5,
-        mimeType: "image/png",
-      };
-      getMock.mockResolvedValueOnce({ data: info });
-      const result = await store.getDppMediaInfo("uuid", "field");
-      expect(result).toEqual(info);
-      expect(getMock).toHaveBeenCalledWith(
-        expect.stringMatching(/\/media\/dpp\/uuid\/field\/info$/),
-      );
-    });
-  });
-
-  describe("downloadDppMedia", () => {
-    it("throws if no uuid provided", async () => {
-      const store = useMediaStore();
-      await expect(store.downloadDppMedia(undefined, "field")).rejects.toThrow("No UUID provided");
-    });
-
-    it("returns blob from endpoint", async () => {
-      const store = useMediaStore();
-      const blob = new Blob(["hello"], { type: "text/plain" });
-      getMock.mockResolvedValueOnce({ data: blob });
-      const result = await store.downloadDppMedia("uuid", "field");
-      expect(result).toEqual(blob);
-      expect(getMock).toHaveBeenCalledWith(
-        expect.stringMatching(/\/media\/dpp\/uuid\/field\/download$/),
-        expect.any(Object),
-      );
-    });
-  });
-
-  describe("fetchDppMedia", () => {
-    it("combines info and blob (contentType from info)", async () => {
+  // ADR 0006 (Design C): public file media gated through the permalink, keyed by mediaId.
+  describe("fetchPermalinkMedia", () => {
+    it("combines info and blob from the permalink-gated by-id routes", async () => {
       const store = useMediaStore();
       const blob = new Blob(["data"], { type: "application/octet-stream" });
 
-      // Mock axios GET to return appropriate responses irrespective of call order
       getMock.mockImplementation((url: string) => {
         if (url.includes("/info")) {
           return Promise.resolve({
-            data: {
-              id: "",
-              title: "",
-              size: 5,
-              mimeType: "image/jpeg",
-            },
+            data: { id: "m-1", title: "", size: 5, mimeType: "image/jpeg" } satisfies MediaInfo,
           });
         }
         if (url.includes("/download")) {
@@ -166,10 +60,13 @@ describe("media store", () => {
         return Promise.reject(new Error(`Unexpected URL ${url}`));
       });
 
-      const result = await store.fetchDppMedia("uuid", "field");
+      const result = await store.fetchPermalinkMedia("slug-1", "m-1");
       expect(result.blob).toEqual(blob);
       expect(result.mediaInfo.mimeType).toEqual("image/jpeg");
-      expect(getMock).toHaveBeenCalledTimes(2);
+      expect(getMock).toHaveBeenCalledWith("/media/permalink/slug-1/by-id/m-1/info");
+      expect(getMock).toHaveBeenCalledWith("/media/permalink/slug-1/by-id/m-1/download", {
+        responseType: "blob",
+      });
     });
   });
 });

--- a/apps/client/src/stores/media.ts
+++ b/apps/client/src/stores/media.ts
@@ -13,51 +13,12 @@ export const useMediaStore = defineStore("media", () => {
     return apiClient.media.media.uploadGeneralMedia(file, onUploadProgress);
   };
 
-  const uploadDppMedia = async (
-    uuid: string,
-    dataFieldId: string,
-    file: File,
-    onUploadProgress?: (progress: number) => void,
-  ): Promise<string> => {
-    return apiClient.media.media.uploadDppMedia(uuid, dataFieldId, file, onUploadProgress);
-  };
-
-  const getDppMediaInfo = async (
-    uuid: string | undefined,
-    dataFieldId: string,
-  ): Promise<MediaInfo> => {
-    if (!uuid) {
-      throw new Error("No UUID provided");
-    }
-    const response = await apiClient.media.media.getMediaInfoOfDataField(uuid, dataFieldId);
-    return response.data;
-  };
-
   const getMediaInfo = async (id: string | undefined): Promise<MediaInfo> => {
     if (!id) {
       throw new Error("No ID provided");
     }
     const response = await apiClient.media.media.getMediaInfo(id);
     return response.data;
-  };
-
-  const downloadDppMedia = async (uuid: string | undefined, dataFieldId: string): Promise<Blob> => {
-    if (!uuid) {
-      throw new Error("No UUID provided");
-    }
-    const response = await apiClient.media.media.downloadMediaOfDataField(uuid, dataFieldId);
-    return response.data;
-  };
-
-  const fetchDppMedia = async (
-    uuid: string | undefined,
-    dataFieldId: string,
-  ): Promise<{ blob: Blob; mediaInfo: MediaInfo }> => {
-    const [info, blob] = await Promise.all([
-      getDppMediaInfo(uuid, dataFieldId),
-      downloadDppMedia(uuid, dataFieldId),
-    ]);
-    return { blob, mediaInfo: info };
   };
 
   const downloadMedia = async (id: string): Promise<Blob | null> => {
@@ -77,6 +38,19 @@ export const useMediaStore = defineStore("media", () => {
     return { blob, mediaInfo: info };
   };
 
+  // ADR 0006 (Design C): public file media is gated through the permalink,
+  // so access dies with the permalink — mirrors fetchMedia but routes by-id.
+  const fetchPermalinkMedia = async (
+    permalinkIdOrSlug: string,
+    mediaId: string,
+  ): Promise<MediaResult> => {
+    const [infoResponse, blobResponse] = await Promise.all([
+      apiClient.media.media.getPermalinkMediaInfo(permalinkIdOrSlug, mediaId),
+      apiClient.media.media.downloadPermalinkMedia(permalinkIdOrSlug, mediaId),
+    ]);
+    return { blob: blobResponse.data, mediaInfo: infoResponse.data };
+  };
+
   const fetchMediaByOrganizationId = async (): Promise<Array<MediaInfo>> => {
     const response = await apiClient.media.media.getMediaInfoByOrganization();
     const media = response.data as Array<MediaInfo>;
@@ -89,16 +63,13 @@ export const useMediaStore = defineStore("media", () => {
   };
 
   return {
-    getDppMediaInfo,
-    downloadDppMedia,
-    fetchDppMedia,
     fetchMediaByOrganizationId,
     downloadMedia,
     getMediaInfo,
     fetchMedia,
+    fetchPermalinkMedia,
     uploadMedia,
     deleteMedia,
-    uploadDppMedia,
     organizationMedia,
   };
 });

--- a/apps/main/src/ai/ai.module.ts
+++ b/apps/main/src/ai/ai.module.ts
@@ -4,7 +4,6 @@ import { EnvModule } from "@open-dpp/env";
 import { PassportsModule } from "../passports/passports.module";
 import { PermalinkModule } from "../permalink/permalink.module";
 import { PolicyModule } from "../policy/policy.module";
-import { UniqueProductIdentifierModule } from "../unique-product-identifier/unique.product.identifier.module";
 import {
   AiConfigurationDbSchema,
   AiConfigurationDoc,
@@ -23,7 +22,6 @@ import { McpClientModule } from "./mcp-client/mcp-client.module";
         schema: AiConfigurationDbSchema,
       },
     ]),
-    UniqueProductIdentifierModule,
     EnvModule,
     McpClientModule,
     PolicyModule,

--- a/apps/main/src/ai/chat.service.spec.ts
+++ b/apps/main/src/ai/chat.service.spec.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it, jest } from "@jest/globals";
+import { ChatService } from "./chat.service";
+
+describe("ChatService.askAgent (ADR 0006)", () => {
+  it("resolves the passport by passportId and throws when it is missing — no UPI lookup", async () => {
+    const findOne = jest.fn<any>().mockResolvedValue(undefined);
+    const service = new ChatService(
+      {} as never, // mcpClientService
+      {} as never, // aiService
+      {} as never, // aiConfigurationService
+      {} as never, // policyService
+      { findOne } as never, // passportRepository
+    );
+
+    await expect(service.askAgent("hi", "passport-1", null, null)).rejects.toThrow(
+      "Product passport passport-1 not found",
+    );
+    expect(findOne).toHaveBeenCalledWith("passport-1");
+  });
+});

--- a/apps/main/src/ai/chat.service.ts
+++ b/apps/main/src/ai/chat.service.ts
@@ -7,7 +7,6 @@ import { User } from "../identity/users/domain/user";
 import { PassportRepository } from "../passports/infrastructure/passport.repository";
 import { PolicyKey } from "../policy/domain/policy";
 import { PolicyService } from "../policy/infrastructure/policy.service";
-import { UniqueProductIdentifierRepository } from "../unique-product-identifier/infrastructure/unique-product-identifier.repository";
 import { AiConfigurationService } from "./ai-configuration/infrastructure/ai-configuration.service";
 import { AiService } from "./infrastructure/ai.service";
 import { McpClientService } from "./mcp-client/mcp-client.service";
@@ -18,7 +17,6 @@ export class ChatService {
 
   private readonly mcpClientService: McpClientService;
   private readonly aiService: AiService;
-  private readonly uniqueProductIdentifierRepository: UniqueProductIdentifierRepository;
   private readonly aiConfigurationService: AiConfigurationService;
   private readonly policyService: PolicyService;
   private readonly passportRepository: PassportRepository;
@@ -26,36 +24,24 @@ export class ChatService {
   constructor(
     mcpClientService: McpClientService,
     aiService: AiService,
-    uniqueProductIdentifierRepository: UniqueProductIdentifierRepository,
     aiConfigurationService: AiConfigurationService,
     policyService: PolicyService,
     passportRepository: PassportRepository,
   ) {
     this.mcpClientService = mcpClientService;
     this.aiService = aiService;
-    this.uniqueProductIdentifierRepository = uniqueProductIdentifierRepository;
     this.aiConfigurationService = aiConfigurationService;
     this.policyService = policyService;
     this.passportRepository = passportRepository;
   }
 
-  async askAgent(
-    query: string,
-    uniqueProductIdentifierUuid: string,
-    user: User | null,
-    member: Member | null,
-  ) {
-    this.logger.log(
-      `Resolve passport from UniqueProductIdentifier: ${uniqueProductIdentifierUuid}`,
-    );
-    const uniqueProductIdentifier = await this.uniqueProductIdentifierRepository.findOneOrFail(
-      uniqueProductIdentifierUuid,
-    );
-    const passport = await this.passportRepository.findOne(uniqueProductIdentifier.referenceId);
+  async askAgent(query: string, passportId: string, user: User | null, member: Member | null) {
+    // ADR 0006: the AI agent operates on the passport directly (the system prompt is
+    // keyed by passportId); resolve it without the canonical UPI indirection.
+    this.logger.log(`Resolve passport: ${passportId}`);
+    const passport = await this.passportRepository.findOne(passportId);
     if (!passport) {
-      throw new Error(
-        `Product passport for UniqueProductIdentifier ${uniqueProductIdentifierUuid} not found`,
-      );
+      throw new Error(`Product passport ${passportId} not found`);
     }
 
     // Check quota BEFORE processing

--- a/apps/main/src/ai/presentation/chat.gateway.ts
+++ b/apps/main/src/ai/presentation/chat.gateway.ts
@@ -11,7 +11,6 @@ import { Server, Socket } from "socket.io";
 import { WebsocketAuthGuard } from "../../identity/auth/infrastructure/guards/websocket-auth.guard";
 import { OptionalAuth } from "../../identity/auth/presentation/decorators/optional-auth.decorator";
 import { PermalinkApplicationService } from "../../permalink/application/services/permalink.application.service";
-import { UniqueProductIdentifierRepository } from "../../unique-product-identifier/infrastructure/unique-product-identifier.repository";
 import { ChatService } from "../chat.service";
 
 @UseGuards(WebsocketAuthGuard)
@@ -26,7 +25,6 @@ export class ChatGateway {
   constructor(
     private readonly chatService: ChatService,
     private readonly permalinkApplicationService: PermalinkApplicationService,
-    private readonly uniqueProductIdentifierRepository: UniqueProductIdentifierRepository,
   ) {}
 
   @OptionalAuth()
@@ -46,17 +44,11 @@ export class ChatGateway {
           memberRole: client.data.member?.role,
         },
       );
-      const upi = await this.uniqueProductIdentifierRepository.findOneByReferencedId(passport.id);
-      if (!upi) {
-        this.logger.error(
-          `No UniqueProductIdentifier found for passport ${passport.id} (permalink=${message.permalink})`,
-        );
-        throw new Error("No product identifier found for the provided permalink");
-      }
 
+      // ADR 0006: pass the resolved passportId straight to the agent — no canonical UPI hop.
       const reply = await this.chatService.askAgent(
         message.msg,
-        upi.uuid,
+        passport.id,
         client.data.user,
         client.data.member,
       );

--- a/apps/main/src/branding/branding.module.ts
+++ b/apps/main/src/branding/branding.module.ts
@@ -3,6 +3,7 @@ import { MongooseModule } from "@nestjs/mongoose";
 import { EnvModule } from "@open-dpp/env";
 import { AasModule } from "../aas/aas.module";
 import { OrganizationsModule } from "../identity/organizations/organizations.module";
+import { MediaModule } from "../media/media.module";
 import { BrandingRepository } from "./infrastructure/branding.repository";
 import { BrandingDoc, BrandingSchema } from "./infrastructure/branding.schema";
 import { BrandingController } from "./presentation/branding.controller";
@@ -18,6 +19,7 @@ import { BrandingController } from "./presentation/branding.controller";
     AasModule,
     OrganizationsModule,
     EnvModule,
+    MediaModule,
   ],
   controllers: [BrandingController],
   providers: [BrandingRepository],

--- a/apps/main/src/branding/infrastructure/branding.repository.spec.ts
+++ b/apps/main/src/branding/infrastructure/branding.repository.spec.ts
@@ -93,6 +93,39 @@ describe("brandingRepository", () => {
     expect(migratedBranding.logo).toBe(logo);
   });
 
+  describe("isOrganizationLogo", () => {
+    it("returns true only when the media is the org's designated logo (no cross-org exposure)", async () => {
+      const orgId = randomUUID();
+      const otherOrgId = randomUUID();
+      const logoMediaId = randomUUID();
+      jest
+        .spyOn(organizationService, "getOrganization")
+        .mockResolvedValue(Organization.create({ name: "acme", slug: `acme-${randomUUID()}` }));
+      await brandingRepository.save(Branding.create({ organizationId: orgId, logo: logoMediaId }));
+
+      // owning org designated it as its logo → public
+      expect(await brandingRepository.isOrganizationLogo(logoMediaId, orgId)).toBe(true);
+      // another org's effective logo is not this media (no cross-org exposure)
+      expect(await brandingRepository.isOrganizationLogo(logoMediaId, otherOrgId)).toBe(false);
+      // a non-logo media id is never public
+      expect(await brandingRepository.isOrganizationLogo(randomUUID(), orgId)).toBe(false);
+    });
+
+    it("resolves the legacy organization.logo fallback for orgs without a BrandingDoc", async () => {
+      const orgId = randomUUID();
+      const legacyLogo = randomUUID();
+      jest
+        .spyOn(organizationService, "getOrganization")
+        .mockResolvedValue(
+          Organization.create({ name: "acme", slug: `acme-${randomUUID()}`, logo: legacyLogo }),
+        );
+
+      // no BrandingDoc saved → must still recognize the org.logo fallback (regression guard)
+      expect(await brandingRepository.isOrganizationLogo(legacyLogo, orgId)).toBe(true);
+      expect(await brandingRepository.isOrganizationLogo(randomUUID(), orgId)).toBe(false);
+    });
+  });
+
   it("should migrate logo from organization on save", async () => {
     const orgId = randomUUID();
     const logo = "logo-from-organization";

--- a/apps/main/src/branding/infrastructure/branding.repository.ts
+++ b/apps/main/src/branding/infrastructure/branding.repository.ts
@@ -20,6 +20,19 @@ export class BrandingRepository {
     private readonly BrandingDoc: MongooseModel<BrandingDoc>,
   ) {}
 
+  /**
+   * Whether `mediaId` is the EFFECTIVE branding logo of `organizationId`, resolved through the
+   * same source that advertises it (`findOneByOrganizationId`) — so it also covers the legacy
+   * `organization.logo` fallback for orgs that have no `BrandingDoc` yet.
+   *
+   * Gates the public logo route: callers pass the MEDIA's owning org, so an org can only ever
+   * expose its own designated logo — never another org's media by pointing its branding at it.
+   */
+  async isOrganizationLogo(mediaId: string, organizationId: string): Promise<boolean> {
+    const branding = await this.findOneByOrganizationId(organizationId);
+    return branding.logo === mediaId;
+  }
+
   async findOneByOrganizationId(organizationId: string): Promise<Branding> {
     const brandingDoc = await this.BrandingDoc.findOne({ organizationId });
 
@@ -54,7 +67,7 @@ export class BrandingRepository {
         throw new NotFoundException("Organization not found");
       }
 
-      brandingDoc = new this.BrandingDoc({ _schemaVersion: BrandingDocVersion.v1_1_0 });
+      brandingDoc = new this.BrandingDoc({ _schemaVersion: BrandingDocVersion.v1_2_0 });
 
       if (activeOrganization.logo) {
         this.logger.debug("migrating old to new logo");
@@ -64,7 +77,7 @@ export class BrandingRepository {
 
     const plain = branding.toPlain();
     brandingDoc.set({
-      _schemaVersion: BrandingDocVersion.v1_1_0,
+      _schemaVersion: BrandingDocVersion.v1_2_0,
       ...plain,
       logo: plain.logo ?? orgLogoFallback,
     });

--- a/apps/main/src/branding/infrastructure/branding.schema.ts
+++ b/apps/main/src/branding/infrastructure/branding.schema.ts
@@ -4,13 +4,14 @@ import { Document } from "mongoose";
 export const BrandingDocVersion = {
   v1_0_0: "1.0.0",
   v1_1_0: "1.1.0",
+  v1_2_0: "1.2.0",
 } as const;
 type BrandingDocVersionType = (typeof BrandingDocVersion)[keyof typeof BrandingDocVersion];
 
 @Schema({ collection: "branding" })
 export class BrandingDoc extends Document<string> {
   @Prop({
-    default: BrandingDocVersion.v1_1_0,
+    default: BrandingDocVersion.v1_2_0,
     enum: Object.values(BrandingDocVersion),
     type: String,
   })

--- a/apps/main/src/branding/presentation/branding.controller.spec.ts
+++ b/apps/main/src/branding/presentation/branding.controller.spec.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, jest } from "@jest/globals";
+import { BrandingController } from "./branding.controller";
+
+function makeRes() {
+  const res: Record<string, unknown> = { headersSent: false };
+  res.setHeader = jest.fn();
+  res.status = jest.fn(() => res);
+  res.json = jest.fn(() => res);
+  res.destroy = jest.fn();
+  return res as never;
+}
+
+function make(opts: { media?: unknown; isOwnLogo?: boolean } = {}) {
+  const brandingRepository = {
+    isOrganizationLogo: jest.fn<any>(async () => opts.isOwnLogo ?? false),
+  };
+  const mediaService = {
+    findOneOrFail: jest.fn<any>(
+      async () =>
+        opts.media ?? { id: "m-1", ownedByOrganizationId: "org-1", mimeType: "image/png" },
+    ),
+    getFilestreamOfMedia: jest.fn<any>(async () => ({ pipe: jest.fn(), on: jest.fn() })),
+  };
+  const controller = new BrandingController(brandingRepository as never, mediaService as never);
+  return { controller, brandingRepository, mediaService };
+}
+
+describe("BrandingController.getOrganizationLogo (public, ownership-gated)", () => {
+  it("streams the media when it is its owning org's branding logo", async () => {
+    const { controller, brandingRepository, mediaService } = make({
+      media: { id: "m-1", ownedByOrganizationId: "org-1", mimeType: "image/png" },
+      isOwnLogo: true,
+    });
+    const res = makeRes();
+
+    await controller.getOrganizationLogo("m-1", res);
+
+    // gate checks ownership: mediaId + the media's OWN org
+    expect(brandingRepository.isOrganizationLogo).toHaveBeenCalledWith("m-1", "org-1");
+    expect(mediaService.getFilestreamOfMedia).toHaveBeenCalled();
+    expect((res as unknown as { status: jest.Mock }).status).not.toHaveBeenCalledWith(404);
+  });
+
+  it("404s when the media is not its owning org's logo (blocks cross-org / arbitrary by-id access)", async () => {
+    const { controller, mediaService } = make({
+      media: { id: "m-1", ownedByOrganizationId: "org-1", mimeType: "image/png" },
+      isOwnLogo: false,
+    });
+    const res = makeRes();
+
+    await controller.getOrganizationLogo("m-1", res);
+
+    expect((res as unknown as { status: jest.Mock }).status).toHaveBeenCalledWith(404);
+    expect(mediaService.getFilestreamOfMedia).not.toHaveBeenCalled();
+  });
+
+  it("404s when the designated logo media is not an image (no passport-file exposure)", async () => {
+    const { controller, mediaService } = make({
+      media: { id: "m-1", ownedByOrganizationId: "org-1", mimeType: "application/pdf" },
+      isOwnLogo: true,
+    });
+    const res = makeRes();
+
+    await controller.getOrganizationLogo("m-1", res);
+
+    expect((res as unknown as { status: jest.Mock }).status).toHaveBeenCalledWith(404);
+    expect(mediaService.getFilestreamOfMedia).not.toHaveBeenCalled();
+  });
+
+  it("404s when the media does not exist", async () => {
+    const { controller, mediaService } = make();
+    mediaService.findOneOrFail.mockRejectedValue(new Error("not found"));
+    const res = makeRes();
+
+    await controller.getOrganizationLogo("missing", res);
+
+    expect((res as unknown as { status: jest.Mock }).status).toHaveBeenCalledWith(404);
+  });
+});

--- a/apps/main/src/branding/presentation/branding.controller.ts
+++ b/apps/main/src/branding/presentation/branding.controller.ts
@@ -1,16 +1,21 @@
 import type express from "express";
 import { readFile } from "node:fs/promises";
-import { Body, Controller, Get, Put, Res } from "@nestjs/common";
+import { Body, Controller, Get, Param, Put, Res } from "@nestjs/common";
 import { type BrandingDto, BrandingDtoSchema } from "@open-dpp/dto";
 import { ZodValidationPipe } from "@open-dpp/exception";
 import { AllowAnonymous } from "../../identity/auth/presentation/decorators/allow-anonymous.decorator";
 import { OrganizationId } from "../../identity/auth/presentation/decorators/organization-id.decorator";
+import { MediaService } from "../../media/infrastructure/media.service";
+import { streamMedia } from "../../media/presentation/media-response.util";
 import { Branding } from "../domain/branding";
 import { BrandingRepository } from "../infrastructure/branding.repository";
 
 @Controller("/branding")
 export class BrandingController {
-  constructor(private readonly brandingRepository: BrandingRepository) {}
+  constructor(
+    private readonly brandingRepository: BrandingRepository,
+    private readonly mediaService: MediaService,
+  ) {}
 
   @Get()
   async getOrganizationBranding(@OrganizationId() organizationId: string): Promise<BrandingDto> {
@@ -43,5 +48,35 @@ export class BrandingController {
     const fileContent = await readFile(file.path);
     response.type(file.filetype);
     return response.send(fileContent);
+  }
+
+  /**
+   * Public organization logo. The bare `/media/:id` route is authenticated, so this is the
+   * one anonymous path to logo bytes — gated so it serves ONLY media that is its owning
+   * org's branding logo (`existsByLogoForOrg`), never arbitrary media by id.
+   */
+  @AllowAnonymous()
+  @Get("/logo/:mediaId")
+  async getOrganizationLogo(
+    @Param("mediaId") mediaId: string,
+    @Res() res: express.Response,
+  ): Promise<void> {
+    try {
+      const media = await this.mediaService.findOneOrFail(mediaId);
+      const isLogo = await this.brandingRepository.isOrganizationLogo(
+        mediaId,
+        media.ownedByOrganizationId,
+      );
+      // A logo is always an image — refuse anything else even if mis-assigned, so a non-image
+      // passport file can never be exposed publicly through this route.
+      if (!isLogo || !media.mimeType.startsWith("image/")) {
+        res.status(404).json({ error: "Logo not found" });
+        return;
+      }
+      const stream = await this.mediaService.getFilestreamOfMedia(media);
+      streamMedia(res, media, stream);
+    } catch {
+      res.status(404).json({ error: "Logo not found" });
+    }
   }
 }

--- a/apps/main/src/media/infrastructure/media.service.spec.ts
+++ b/apps/main/src/media/infrastructure/media.service.spec.ts
@@ -153,81 +153,6 @@ describe("MediaService", () => {
     versionId: "v1",
   };
 
-  describe("uploadFileOfProductPassport", () => {
-    it("should upload file and save media", async () => {
-      mockMediaModel.find.mockResolvedValue([]);
-      mockFileTypeFromBuffer.mockResolvedValue({ mime: "application/pdf", ext: "pdf" });
-      mockMinioInstance.bucketExists.mockResolvedValue(true);
-      mockMinioInstance.putObject.mockResolvedValue({ etag: "etag", versionId: "v1" });
-      mockMediaModel.findOneAndUpdate.mockResolvedValue(validMediaDoc);
-
-      const buffer = Buffer.from("test");
-      const result = await service.uploadFileOfProductPassport(
-        "file.pdf",
-        buffer,
-        "field-id",
-        "upid",
-        "user-id",
-        "org-id",
-      );
-
-      expect(mockMediaModel.find).toHaveBeenCalled();
-      expect(mockMinioInstance.putObject).toHaveBeenCalled();
-      expect(mockMediaModel.findOneAndUpdate).toHaveBeenCalled();
-      expect(result).toBeInstanceOf(Media);
-    });
-
-    it("should delete existing media if found", async () => {
-      mockMediaModel.find.mockResolvedValue([{ _id: "existing" }]);
-      mockFileTypeFromBuffer.mockResolvedValue({ mime: "application/pdf", ext: "pdf" });
-      mockMinioInstance.bucketExists.mockResolvedValue(true);
-      mockMinioInstance.putObject.mockResolvedValue({ etag: "etag", versionId: "v1" });
-      mockMediaModel.findOneAndUpdate.mockResolvedValue(validMediaDoc);
-
-      await service.uploadFileOfProductPassport(
-        "file.pdf",
-        Buffer.from("test"),
-        "field-id",
-        "upid",
-        "user-id",
-        "org-id",
-      );
-
-      expect(mockMediaModel.deleteMany).toHaveBeenCalledWith({
-        dataFieldId: "field-id",
-        uniqueProductIdentifier: "upid",
-      });
-    });
-
-    it("should process image if mimetype starts with image/", async () => {
-      mockMediaModel.find.mockResolvedValue([]);
-      mockFileTypeFromBuffer.mockResolvedValue({ mime: "image/png", ext: "png" });
-      mockMinioInstance.bucketExists.mockResolvedValue(true);
-      mockMinioInstance.putObject.mockResolvedValue({ etag: "etag" });
-      mockMediaModel.findOneAndUpdate.mockResolvedValue({
-        ...validMediaDoc,
-        mimeType: "image/webp",
-      });
-
-      await service.uploadFileOfProductPassport(
-        "img.png",
-        Buffer.from("img"),
-        "fid",
-        "upid",
-        "uid",
-        "oid",
-      );
-
-      expect(mockMinioInstance.putObject).toHaveBeenCalledWith(
-        expect.anything(),
-        expect.anything(),
-        expect.objectContaining({ length: 15 }), // "processed-image".length
-        expect.anything(),
-        expect.anything(),
-      );
-    });
-  });
-
   describe("uploadMedia", () => {
     it("should upload media", async () => {
       mockFileTypeFromBuffer.mockResolvedValue({ mime: "application/pdf", ext: "pdf" });
@@ -255,18 +180,6 @@ describe("MediaService", () => {
     it("should throw if bucket does not exist", async () => {
       mockMinioInstance.bucketExists.mockResolvedValue(false);
       await expect(service.getFileStream("bucket", "file")).rejects.toThrow();
-    });
-  });
-
-  describe("getFilestreamOfProductPassport", () => {
-    it("should return stream and media", async () => {
-      mockMediaModel.find.mockResolvedValue([validMediaDoc]);
-      mockMinioInstance.bucketExists.mockResolvedValue(true);
-      mockMinioInstance.getObject.mockResolvedValue("stream");
-
-      const result = await service.getFilestreamOfProductPassport("fid", "upid");
-      expect(result.stream).toBe("stream");
-      expect(result.media).toBeInstanceOf(Media);
     });
   });
 
@@ -321,19 +234,6 @@ describe("MediaService", () => {
     it("should throw if not found", async () => {
       mockMediaModel.findById.mockResolvedValue(null);
       await expect(service.findOneOrFail("id")).rejects.toThrow();
-    });
-  });
-
-  describe("findOneDppFileOrFail", () => {
-    it("should return domain object", async () => {
-      mockMediaModel.find.mockResolvedValue([validMediaDoc]);
-      const result = await service.findOneDppFileOrFail("fid", "upid");
-      expect(result).toBeInstanceOf(Media);
-    });
-
-    it("should throw if not found", async () => {
-      mockMediaModel.find.mockResolvedValue([]);
-      await expect(service.findOneDppFileOrFail("fid", "upid")).rejects.toThrow();
     });
   });
 

--- a/apps/main/src/media/infrastructure/media.service.ts
+++ b/apps/main/src/media/infrastructure/media.service.ts
@@ -95,62 +95,6 @@ export class MediaService {
     return await sharp(buffer).webp({ quality: 85 }).toBuffer();
   }
 
-  async uploadFileOfProductPassport(
-    originalFilename: string,
-    buffer: Buffer,
-    dataFieldId: string,
-    uniqueProductIdentifier: string,
-    createdByUserId: string,
-    ownedByOrganizationId: string,
-  ) {
-    const findMedia = await this.mediaDoc.find({
-      dataFieldId,
-      uniqueProductIdentifier,
-    });
-    if (findMedia.length > 0) {
-      await this.mediaDoc.deleteMany({
-        dataFieldId,
-        uniqueProductIdentifier,
-      });
-    }
-    const fileType = await fileTypeFromBuffer(buffer);
-    if (!fileType) {
-      throw new Error("File type not recognized");
-    }
-    let fileTypeMime = fileType.mime;
-    let uploadBuffer: Buffer = buffer;
-    if (fileType.mime.startsWith("image/")) {
-      uploadBuffer = await this.processImageBuffer(uploadBuffer);
-      fileTypeMime = "image/webp";
-    }
-    const uploadInfo = await this.uploadFile(
-      this.bucketNameDefault,
-      uploadBuffer,
-      dataFieldId,
-      [BucketDefaultPaths.PRODUCT_PASSPORT_FILES, uniqueProductIdentifier],
-      uploadBuffer.length,
-      fileTypeMime,
-    );
-    const media = Media.create({
-      createdByUserId,
-      ownedByOrganizationId,
-      title: originalFilename,
-      description: originalFilename,
-      mimeType: fileTypeMime,
-      fileExtension: fileType.ext,
-      size: uploadBuffer.length,
-      originalFilename,
-      uniqueProductIdentifier,
-      dataFieldId,
-      bucket: uploadInfo.location.bucket,
-      objectName: uploadInfo.location.objectName,
-      eTag: uploadInfo.info.etag,
-      versionId: uploadInfo.info.versionId || this.fallbackMediaVersionId,
-    });
-    await this.save(media);
-    return media;
-  }
-
   async uploadMedia(
     originalFilename: string,
     buffer: Buffer,
@@ -208,15 +152,6 @@ export class MediaService {
     }
     const objectName = this.buildBucketPath(remoteFileBaseName, remoteFolders);
     return await this.client.getObject(bucketName, objectName);
-  }
-
-  async getFilestreamOfProductPassport(dataFieldId: string, uniqueProductIdentifier: string) {
-    const media = await this.findOneDppFileOrFail(dataFieldId, uniqueProductIdentifier);
-    const stream = await this.getFilestreamOfMedia(media);
-    return {
-      stream,
-      media,
-    };
   }
 
   async getFilestreamById(id: string) {
@@ -298,17 +233,6 @@ export class MediaService {
       throw new NotFoundInDatabaseException(Media.name);
     }
     return this.convertToDomain(mediaDocument);
-  }
-
-  async findOneDppFileOrFail(dataFieldId: string, uniqueProductIdentifier: string) {
-    const mediaDocuments = await this.mediaDoc.find({
-      dataFieldId,
-      uniqueProductIdentifier,
-    });
-    if (mediaDocuments.length === 0) {
-      throw new NotFoundInDatabaseException(Media.name);
-    }
-    return this.convertToDomain(mediaDocuments[0]); // Assuming there's only one match
   }
 
   async findAll() {

--- a/apps/main/src/media/media.module.ts
+++ b/apps/main/src/media/media.module.ts
@@ -2,6 +2,7 @@ import { HttpModule } from "@nestjs/axios";
 import { Module } from "@nestjs/common";
 import { MongooseModule } from "@nestjs/mongoose";
 import { EnvModule } from "@open-dpp/env";
+import { OrganizationsModule } from "../identity/organizations/organizations.module";
 import { MediaDbSchema, MediaDoc } from "./infrastructure/media.schema";
 import { MediaService } from "./infrastructure/media.service";
 import { MediaController } from "./presentation/media.controller";
@@ -16,6 +17,7 @@ import { MediaController } from "./presentation/media.controller";
     ]),
     HttpModule,
     EnvModule,
+    OrganizationsModule,
   ],
   providers: [MediaService],
   controllers: [MediaController],

--- a/apps/main/src/media/presentation/media-response.util.spec.ts
+++ b/apps/main/src/media/presentation/media-response.util.spec.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, jest } from "@jest/globals";
+import { setSafeMediaHeaders, streamMedia, toPublicMediaInfo } from "./media-response.util";
+
+function makeRes() {
+  const headers: Record<string, string> = {};
+  const res = {
+    headersSent: false,
+    setHeader: jest.fn((k: string, v: string) => {
+      headers[k] = v;
+    }),
+    status: jest.fn(() => res),
+    json: jest.fn(() => res),
+    destroy: jest.fn(),
+  };
+  return { res, headers };
+}
+
+function makeStream() {
+  let errorHandler: ((e: Error) => void) | undefined;
+  const stream = {
+    pipe: jest.fn(),
+    on: jest.fn((event: string, cb: (e: Error) => void) => {
+      if (event === "error") {
+        errorHandler = cb;
+      }
+    }),
+  };
+  return { stream, fireError: (e: Error) => errorHandler?.(e) };
+}
+
+describe("setSafeMediaHeaders", () => {
+  it("always sets X-Content-Type-Options: nosniff", () => {
+    const { res, headers } = makeRes();
+    setSafeMediaHeaders(res as never, { mimeType: "application/pdf" } as never);
+    expect(headers["X-Content-Type-Options"]).toBe("nosniff");
+  });
+
+  it("echoes an allowlisted content-type and does not force an attachment", () => {
+    const { res, headers } = makeRes();
+    setSafeMediaHeaders(res as never, { mimeType: "image/webp" } as never);
+    expect(headers["Content-Type"]).toBe("image/webp");
+    expect(headers["Content-Disposition"]).toBeUndefined();
+  });
+
+  it("clamps a non-allowlisted content-type to octet-stream + attachment (XSS guard)", () => {
+    const { res, headers } = makeRes();
+    setSafeMediaHeaders(res as never, { mimeType: "text/html" } as never);
+    expect(headers["Content-Type"]).toBe("application/octet-stream");
+    expect(headers["Content-Disposition"]).toBe("attachment");
+    expect(headers["X-Content-Type-Options"]).toBe("nosniff");
+  });
+});
+
+describe("toPublicMediaInfo", () => {
+  it("keeps only the public fields and drops internal storage/ownership details", () => {
+    const media = {
+      id: "m-1",
+      title: "doc.pdf",
+      mimeType: "application/pdf",
+      size: 42,
+      bucket: "secret-bucket",
+      objectName: "product-passport-files/abc",
+      eTag: "etag",
+      versionId: "v1",
+      ownedByOrganizationId: "org-1",
+      createdByUserId: "user-1",
+    };
+    expect(toPublicMediaInfo(media as never)).toEqual({
+      id: "m-1",
+      title: "doc.pdf",
+      mimeType: "application/pdf",
+      size: 42,
+    });
+  });
+});
+
+describe("streamMedia", () => {
+  it("sets safe headers and pipes the stream to the response", () => {
+    const { res, headers } = makeRes();
+    const { stream } = makeStream();
+    streamMedia(res as never, { mimeType: "application/pdf" } as never, stream as never);
+    expect(headers["X-Content-Type-Options"]).toBe("nosniff");
+    expect(stream.pipe).toHaveBeenCalledWith(res);
+  });
+
+  it("destroys the response on a mid-stream error after headers are sent (no socket leak)", () => {
+    const { res } = makeRes();
+    res.headersSent = true;
+    const { stream, fireError } = makeStream();
+    streamMedia(res as never, { mimeType: "application/pdf" } as never, stream as never);
+    fireError(new Error("S3 down"));
+    expect(res.destroy).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it("sends a 500 when the stream errors before headers are sent", () => {
+    const { res } = makeRes();
+    res.headersSent = false;
+    const { stream, fireError } = makeStream();
+    streamMedia(res as never, { mimeType: "application/pdf" } as never, stream as never);
+    fireError(new Error("early"));
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.destroy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/main/src/media/presentation/media-response.util.ts
+++ b/apps/main/src/media/presentation/media-response.util.ts
@@ -1,0 +1,82 @@
+import type { Response } from "express";
+import type { Readable } from "node:stream";
+import type { Media } from "../domain/media";
+
+/**
+ * Content-types the upload pipeline can ever produce: images are normalized to webp
+ * and PDFs are kept as-is (see `MediaService.uploadMedia`). The original image
+ * extensions are listed too so legacy rows still render.
+ */
+const ALLOWED_MEDIA_CONTENT_TYPES = new Set([
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "image/heic",
+  "application/pdf",
+]);
+
+/**
+ * Set hardened response headers for serving user-uploaded media.
+ *
+ * Defends against stored-XSS via MIME sniffing: `X-Content-Type-Options: nosniff`
+ * stops the browser from re-interpreting the bytes, and the Content-Type is clamped to
+ * the upload allowlist so a crafted file can never be served as an HTML/script type.
+ * Anything outside the allowlist is forced to a non-rendering attachment download.
+ */
+export function setSafeMediaHeaders(res: Response, media: Media): void {
+  const isAllowed = ALLOWED_MEDIA_CONTENT_TYPES.has(media.mimeType);
+  const safeContentType = isAllowed ? media.mimeType : "application/octet-stream";
+
+  res.setHeader("Content-Type", safeContentType);
+  res.setHeader("X-Content-Type-Options", "nosniff");
+  res.setHeader("Cross-Origin-Resource-Policy", "same-site");
+  if (!isAllowed) {
+    res.setHeader("Content-Disposition", "attachment");
+  }
+  if (media.updatedAt) {
+    res.setHeader("Last-Modified", media.updatedAt.toUTCString());
+  }
+  res.setHeader("Cache-Control", "private, max-age=31536000");
+}
+
+/** Public-safe projection of a Media — exactly the api-client `MediaInfoDto` shape. */
+export interface PublicMediaInfo {
+  id: string;
+  title: string;
+  mimeType: string;
+  size: number;
+}
+
+/**
+ * Project a Media down to the fields an anonymous caller may see. The raw domain object
+ * would otherwise serialize internal storage and ownership details (bucket, objectName,
+ * eTag, versionId, ownedByOrganizationId, createdByUserId, …) to the public `/info` routes.
+ */
+export function toPublicMediaInfo(media: Media): PublicMediaInfo {
+  return {
+    id: media.id,
+    title: media.title,
+    mimeType: media.mimeType,
+    size: media.size,
+  };
+}
+
+/**
+ * Stream user-uploaded media to the response with hardened headers, finalizing the
+ * connection on a mid-stream source error.
+ *
+ * Once headers are flushed the error guard can no longer send a status code, so the
+ * socket must be destroyed — otherwise a failed S3 read leaves a hung, half-open
+ * response (a socket/FD leak that a reverse proxy only reaps on idle timeout).
+ */
+export function streamMedia(res: Response, media: Media, stream: Readable): void {
+  setSafeMediaHeaders(res, media);
+  stream.pipe(res);
+  stream.on("error", (err: Error) => {
+    if (res.headersSent) {
+      res.destroy(err);
+    } else {
+      res.status(500).json({ error: "Failed to retrieve file" });
+    }
+  });
+}

--- a/apps/main/src/media/presentation/media.controller.authz.spec.ts
+++ b/apps/main/src/media/presentation/media.controller.authz.spec.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, jest } from "@jest/globals";
+import { NotFoundException } from "@nestjs/common";
+import { MediaController } from "./media.controller";
+
+const MEDIA = {
+  id: "m-1",
+  ownedByOrganizationId: "org-1",
+  mimeType: "image/png",
+  title: "x",
+  size: 1,
+};
+const SESSION = { userId: "u-1" } as never;
+
+function makeRes() {
+  const res: Record<string, unknown> = { headersSent: false };
+  res.setHeader = jest.fn();
+  res.status = jest.fn(() => res);
+  res.json = jest.fn(() => res);
+  res.destroy = jest.fn();
+  return res as never;
+}
+
+function make(isMember: boolean) {
+  const filesService = {
+    findOneOrFail: jest.fn<any>(async () => MEDIA),
+    getFilestreamOfMedia: jest.fn<any>(async () => ({ pipe: jest.fn(), on: jest.fn() })),
+    deleteFileById: jest.fn<any>(async () => undefined),
+  };
+  const membersService = {
+    isMemberOfOrganization: jest.fn<any>(async () => isMember),
+  };
+  const controller = new MediaController(filesService as never, membersService as never);
+  return { controller, filesService, membersService };
+}
+
+describe("MediaController bare /media/:id — membership gate (cross-org IDOR)", () => {
+  it("derives authorization from the media's OWNING org, not the request", async () => {
+    const { controller, membersService } = make(true);
+    await controller.getMediaInfo("m-1", SESSION);
+    expect(membersService.isMemberOfOrganization).toHaveBeenCalledWith("u-1", "org-1");
+  });
+
+  describe("non-member caller", () => {
+    it("download → 404, stream never opened", async () => {
+      const { controller, filesService } = make(false);
+      const res = makeRes();
+      await controller.streamFile("m-1", SESSION, res);
+      expect((res as unknown as { status: jest.Mock }).status).toHaveBeenCalledWith(404);
+      expect(filesService.getFilestreamOfMedia).not.toHaveBeenCalled();
+    });
+
+    it("info → NotFoundException", async () => {
+      const { controller } = make(false);
+      await expect(controller.getMediaInfo("m-1", SESSION)).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+    });
+
+    it("delete → NotFoundException, nothing deleted", async () => {
+      const { controller, filesService } = make(false);
+      await expect(controller.deleteFile("m-1", SESSION)).rejects.toBeInstanceOf(NotFoundException);
+      expect(filesService.deleteFileById).not.toHaveBeenCalled();
+    });
+  });
+
+  it("not-found media throws the SAME NotFoundException as not-member (no existence oracle)", async () => {
+    const { controller, filesService } = make(true);
+    filesService.findOneOrFail.mockRejectedValue(new Error("NotFoundInDatabase"));
+    // same exception type/shape whether the media is absent or the caller is not a member
+    await expect(controller.getMediaInfo("missing", SESSION)).rejects.toBeInstanceOf(
+      NotFoundException,
+    );
+  });
+
+  describe("member caller", () => {
+    it("download streams the media", async () => {
+      const { controller, filesService } = make(true);
+      const res = makeRes();
+      await controller.streamFile("m-1", SESSION, res);
+      expect(filesService.getFilestreamOfMedia).toHaveBeenCalled();
+      expect((res as unknown as { status: jest.Mock }).status).not.toHaveBeenCalledWith(404);
+    });
+
+    it("info returns the public projection", async () => {
+      const { controller } = make(true);
+      const info = await controller.getMediaInfo("m-1", SESSION);
+      expect(info).toEqual({ id: "m-1", title: "x", mimeType: "image/png", size: 1 });
+    });
+
+    it("delete removes the media", async () => {
+      const { controller, filesService } = make(true);
+      await controller.deleteFile("m-1", SESSION);
+      expect(filesService.deleteFileById).toHaveBeenCalledWith("m-1");
+    });
+  });
+});

--- a/apps/main/src/media/presentation/media.controller.ts
+++ b/apps/main/src/media/presentation/media.controller.ts
@@ -6,6 +6,7 @@ import {
   FileTypeValidator,
   Get,
   MaxFileSizeValidator,
+  NotFoundException,
   Param,
   ParseFilePipe,
   Post,
@@ -16,98 +17,21 @@ import {
 import { FileInterceptor } from "@nestjs/platform-express";
 import { memoryStorage } from "multer";
 import { Session } from "../../identity/auth/domain/session";
-import { AllowAnonymous } from "../../identity/auth/presentation/decorators/allow-anonymous.decorator";
 import { AuthSession } from "../../identity/auth/presentation/decorators/auth-session.decorator";
 import { OrganizationId } from "../../identity/auth/presentation/decorators/organization-id.decorator";
+import { MembersService } from "../../identity/organizations/application/services/members.service";
 import { PolicyKey } from "../../policy/domain/policy";
 import { Policy } from "../../policy/presentation/policy.decorator";
 import { BucketDefaultPaths, MediaService } from "../infrastructure/media.service";
+import { PublicMediaInfo, streamMedia, toPublicMediaInfo } from "./media-response.util";
 import { VirusScanFileValidator } from "./virus-scan.file-validator";
 
 @Controller("media")
 export class MediaController {
-  private readonly filesService: MediaService;
-
-  constructor(filesService: MediaService) {
-    this.filesService = filesService;
-  }
-
-  @Post("dpp/:upi/:dataFieldId")
-  @Policy(PolicyKey.MEDIA_STORAGE_CAP)
-  @UseInterceptors(
-    FileInterceptor("file", {
-      storage: memoryStorage(),
-    }),
-  )
-  async uploadDppFile(
-    @UploadedFile(
-      new ParseFilePipe({
-        validators: [
-          new MaxFileSizeValidator({
-            maxSize: 15 * 1024 * 1024 /* max 15MB */,
-          }),
-          new FileTypeValidator({
-            fileType: /(image\/(jpeg|jpg|png|heic|webp)|application\/pdf)$/,
-          }),
-          new VirusScanFileValidator({ storageType: "memory" }),
-        ],
-      }),
-    )
-    file: Express.Multer.File,
-    @OrganizationId() orgId: string,
-    @Param("upi") upi: string,
-    @Param("dataFieldId") dataFieldId: string,
-    @AuthSession() session: Session,
-  ): Promise<{
-    mediaId: string;
-  }> {
-    const media = await this.filesService.uploadFileOfProductPassport(
-      file.originalname,
-      file.buffer,
-      dataFieldId,
-      upi,
-      session.userId,
-      orgId,
-    );
-    return {
-      mediaId: media.id,
-    };
-  }
-
-  @Get("dpp/:upi/:dataFieldId/info")
-  @AllowAnonymous()
-  async getDppFileInfo(
-    @Param("upi") upi: string,
-    @Param("dataFieldId") dataFieldId: string,
-  ): Promise<Media> {
-    return this.filesService.findOneDppFileOrFail(dataFieldId, upi);
-  }
-
-  @Get("dpp/:upi/:dataFieldId/download")
-  @AllowAnonymous()
-  async streamDppFile(
-    @Param("upi") upi: string,
-    @Param("dataFieldId") dataFieldId: string,
-    @Res() res: express.Response,
-  ): Promise<void> {
-    try {
-      const result = await this.filesService.getFilestreamOfProductPassport(dataFieldId, upi);
-      res.setHeader("Content-Type", result.media.mimeType);
-      res.setHeader("Cross-Origin-Resource-Policy", "same-site");
-      if (result.media.updatedAt) {
-        res.setHeader("Last-Modified", result.media.updatedAt.toUTCString());
-      }
-      res.setHeader("Cache-Control", "private, max-age=31536000");
-      result.stream.pipe(res);
-      result.stream.on("error", () => {
-        if (!res.headersSent) {
-          res.status(500).json({ error: "Failed to retrieve file" });
-        }
-      });
-    } catch {
-      res.status(404).json({ error: "File not found" });
-    }
-  }
+  constructor(
+    private readonly filesService: MediaService,
+    private readonly membersService: MembersService,
+  ) {}
 
   @Get("by-organization")
   async getFileInfoByOrganization(@OrganizationId() organizationId: string): Promise<Array<Media>> {
@@ -115,36 +39,52 @@ export class MediaController {
   }
 
   @Get(":id/download")
-  @AllowAnonymous()
-  async streamFile(@Param("id") id: string, @Res() res: express.Response): Promise<void> {
+  async streamFile(
+    @Param("id") id: string,
+    @AuthSession() session: Session,
+    @Res() res: express.Response,
+  ): Promise<void> {
     try {
-      const result = await this.filesService.getFilestreamById(id);
-      res.setHeader("Content-Type", result.media.mimeType);
-      res.setHeader("Cross-Origin-Resource-Policy", "same-site");
-      if (result.media.updatedAt) {
-        res.setHeader("Last-Modified", result.media.updatedAt.toUTCString());
-      }
-      res.setHeader("Cache-Control", "private, max-age=31536000");
-      result.stream.pipe(res);
-      result.stream.on("error", () => {
-        if (!res.headersSent) {
-          res.status(500).json({ error: "Failed to retrieve file" });
-        }
-      });
+      const media = await this.loadMediaForMember(id, session.userId);
+      const stream = await this.filesService.getFilestreamOfMedia(media);
+      streamMedia(res, media, stream);
     } catch {
       res.status(404).json({ error: "File not found" });
     }
   }
 
   @Get(":id/info")
-  @AllowAnonymous()
-  async getMediaInfo(@Param("id") id: string): Promise<Media> {
-    return await this.filesService.findOneOrFail(id);
+  async getMediaInfo(
+    @Param("id") id: string,
+    @AuthSession() session: Session,
+  ): Promise<PublicMediaInfo> {
+    return toPublicMediaInfo(await this.loadMediaForMember(id, session.userId));
   }
 
   @Delete(":id")
-  async deleteFile(@Param("id") id: string) {
-    return await this.filesService.deleteFileById(id);
+  async deleteFile(@Param("id") id: string, @AuthSession() session: Session) {
+    const media = await this.loadMediaForMember(id, session.userId);
+    return await this.filesService.deleteFileById(media.id);
+  }
+
+  /**
+   * Load a media by id, but only if the caller is a member of the media's OWNING organization
+   * (derived from `media.ownedByOrganizationId`, not the request's active-org header — avoids the
+   * cross-tenant IDOR where any authenticated user reads another org's media by id). 404 otherwise.
+   */
+  private async loadMediaForMember(id: string, userId: string): Promise<Media> {
+    let media: Media;
+    try {
+      media = await this.filesService.findOneOrFail(id);
+    } catch {
+      // Collapse "does not exist" into the same 404 as "not a member" so the response shape
+      // cannot be used to enumerate which mediaIds exist.
+      throw new NotFoundException("Media not found");
+    }
+    if (!(await this.membersService.isMemberOfOrganization(userId, media.ownedByOrganizationId))) {
+      throw new NotFoundException("Media not found");
+    }
+    return media;
   }
 
   @Post("upload")

--- a/apps/main/src/open-api-docs/branding.path.ts
+++ b/apps/main/src/open-api-docs/branding.path.ts
@@ -1,10 +1,16 @@
 import { BrandingDtoSchema } from "@open-dpp/dto";
+import { z } from "zod";
 import { HTTPCode } from "./http.codes";
 import { ContentType } from "./content.types";
 
 const tag = "branding";
 
 const orgaIdHeader = { $ref: "#/components/parameters/OrganizationIdHeader" };
+
+const logoMediaIdParamSchema = z.string().meta({
+  description: "Id of the media designated as the organization's branding logo",
+  param: { in: "path", name: "mediaId" },
+});
 
 export const brandingPaths = {
   "/branding": {
@@ -71,6 +77,29 @@ export const brandingPaths = {
               schema: { type: "string", format: "binary" },
             },
             [ContentType.SVG]: {
+              schema: { type: "string", format: "binary" },
+            },
+          },
+        },
+      },
+    },
+  },
+  "/branding/logo/{mediaId}": {
+    get: {
+      tags: [tag],
+      summary:
+        "Public organization logo image. Anonymous, but serves the media only when it is its owning organization's branding logo.",
+      parameters: [logoMediaIdParamSchema],
+      responses: {
+        [HTTPCode.OK]: {
+          content: {
+            [ContentType.PNG]: {
+              schema: { type: "string", format: "binary" },
+            },
+            [ContentType.JPEG]: {
+              schema: { type: "string", format: "binary" },
+            },
+            [ContentType.WEBP]: {
               schema: { type: "string", format: "binary" },
             },
           },

--- a/apps/main/src/passports/presentation/passport.controller.spec.ts
+++ b/apps/main/src/passports/presentation/passport.controller.spec.ts
@@ -301,7 +301,7 @@ describe("passportController", () => {
     const upidService = ctx.getModuleRef().get(UniqueProductIdentifierRepository);
 
     const upids = await upidService.findAllByReferencedId(response.body.id);
-    expect(upids).toHaveLength(1);
+    expect(upids).toHaveLength(0); // ADR 0006: passports no longer auto-mint a canonical UPI
   });
 
   it(`/POST Create passport from template`, async () => {
@@ -364,7 +364,7 @@ describe("passportController", () => {
     const upidService = ctx.getModuleRef().get(UniqueProductIdentifierRepository);
 
     const upids = await upidService.findAllByReferencedId(response.body.id);
-    expect(upids).toHaveLength(1);
+    expect(upids).toHaveLength(0); // ADR 0006: passports no longer auto-mint a canonical UPI
   });
 
   it(`/POST rolls back the whole transaction when permalink creation fails mid-create`, async () => {
@@ -602,7 +602,7 @@ describe("passportController", () => {
 
     const upidService = ctx.getModuleRef().get(UniqueProductIdentifierRepository);
     const upids = await upidService.findAllByReferencedId(importResponse.body.id);
-    expect(upids).toHaveLength(1);
+    expect(upids).toHaveLength(0); // ADR 0006: passports no longer auto-mint a canonical UPI
   });
 
   it("/POST import passport with invalid data returns 400", async () => {
@@ -736,7 +736,7 @@ describe("passportController", () => {
 
     const upidService = ctx.getModuleRef().get(UniqueProductIdentifierRepository);
     const upids = await upidService.findAllByReferencedId(importResponse.body.id);
-    expect(upids).toHaveLength(1);
+    expect(upids).toHaveLength(0); // ADR 0006: passports no longer auto-mint a canonical UPI
 
     const exportResponse = await request(app.getHttpServer())
       .get(`${basePath}/${importResponse.body.id}/export`)
@@ -773,7 +773,7 @@ describe("passportController", () => {
 
     const upidService = ctx.getModuleRef().get(UniqueProductIdentifierRepository);
     const upids = await upidService.findAllByReferencedId(importResponse.body.id);
-    expect(upids).toHaveLength(1);
+    expect(upids).toHaveLength(0); // ADR 0006: passports no longer auto-mint a canonical UPI
 
     const exportResponse = await request(app.getHttpServer())
       .get(`${basePath}/${importResponse.body.id}/export`)

--- a/apps/main/src/passports/presentation/passport.controller.ts
+++ b/apps/main/src/passports/presentation/passport.controller.ts
@@ -44,7 +44,6 @@ import {
   HttpCode,
   HttpStatus,
   Inject,
-  NotFoundException,
   Param,
   Post,
   Put,
@@ -112,7 +111,6 @@ import { PagingResult } from "../../pagination/paging-result";
 import { PresentationConfigurationService } from "../../presentation-configurations/application/services/presentation-configuration.service";
 import { Template } from "../../templates/domain/template";
 import { TemplateRepository } from "../../templates/infrastructure/template.repository";
-import { UniqueProductIdentifierRepository } from "../../unique-product-identifier/infrastructure/unique-product-identifier.repository";
 import { PassportService } from "../application/services/passport.service";
 import { Passport } from "../domain/passport";
 import { PassportRepository } from "../infrastructure/passport.repository";
@@ -143,7 +141,6 @@ export class PassportController
     private readonly environmentService: EnvironmentService,
     private readonly passportRepository: PassportRepository,
     private readonly templateRepository: TemplateRepository,
-    private readonly uniqueProductIdentifierRepository: UniqueProductIdentifierRepository,
     private readonly passportService: PassportService,
     private readonly aasSerializationService: AasSerializationService,
     @Inject(forwardRef(() => PermalinkApplicationService))
@@ -193,26 +190,6 @@ export class PassportController
         organizationId,
       );
     return PassportDtoSchema.parse(passport.toPlain());
-  }
-
-  @Get(":id/unique-product-identifier")
-  async getUniqueProductIdentifierOfPassport(
-    @OrganizationId() organizationId: string,
-    @IdParam() id: string,
-    @UserRoleDecorator() userRole: UserRoleType,
-    @MemberRoleDecorator() memberRole: MemberRoleType | undefined,
-  ): Promise<{ uuid: string }> {
-    const subject = SubjectAttributes.create({ userRole, memberRole });
-    await this.passportService.digitalProductDocumentService.loadDigitalProductDocumentAndCheckOwnership(
-      id,
-      subject,
-      organizationId,
-    );
-    const upi = await this.uniqueProductIdentifierRepository.findOneByReferencedId(id);
-    if (!upi) {
-      throw new NotFoundException(`No UniqueProductIdentifier found for passport ${id}`);
-    }
-    return { uuid: upi.uuid };
   }
 
   @Delete(":id")
@@ -299,10 +276,9 @@ export class PassportController
       environment,
     });
 
-    const upid = passport.createUniqueProductIdentifier();
-
+    // ADR 0006: passports no longer auto-mint a canonical OPEN_DPP_UUID UPI. Media keys
+    // on the passportId and presentation resolves via permalinks, so no UPI is needed.
     const saved = await this.environmentService.withTransaction(async (options) => {
-      await this.uniqueProductIdentifierRepository.save(upid, options);
       const persisted = await this.passportRepository.save(passport, options);
       const snapshotConfigs =
         await this.presentationConfigurationService.snapshotTemplateConfigsToPassport(
@@ -948,9 +924,8 @@ export class PassportController
       body,
       organizationId,
       async (p, options) => {
+        // ADR 0006: no canonical UPI auto-mint on import.
         await this.passportRepository.save(p, options);
-        const upid = p.createUniqueProductIdentifier();
-        await this.uniqueProductIdentifierRepository.save(upid, options);
       },
       async (p, options) => {
         const importedConfigs = await this.presentationConfigurationService.findExistingForPassport(

--- a/apps/main/src/permalink/permalink.module.ts
+++ b/apps/main/src/permalink/permalink.module.ts
@@ -6,6 +6,7 @@ import { BrandingModule } from "../branding/branding.module";
 import { OrganizationsModule } from "../identity/organizations/organizations.module";
 import { UsersModule } from "../identity/users/users.module";
 import { InstanceSettingsModule } from "../instance-settings/instance-settings.module";
+import { MediaModule } from "../media/media.module";
 import { PassportsModule } from "../passports/passports.module";
 import {
   PresentationConfigurationDoc,
@@ -16,6 +17,7 @@ import { UniqueProductIdentifierModule } from "../unique-product-identifier/uniq
 import { PermalinkDoc, PermalinkSchema } from "./infrastructure/permalink.schema";
 import { PermalinkRepository } from "./infrastructure/permalink.repository";
 import { PermalinkApplicationService } from "./application/services/permalink.application.service";
+import { MediaPermalinkController } from "./presentation/media-permalink.controller";
 import { PermalinkController } from "./presentation/permalink.controller";
 
 @Module({
@@ -29,12 +31,14 @@ import { PermalinkController } from "./presentation/permalink.controller";
     OrganizationsModule,
     UsersModule,
     InstanceSettingsModule,
+    // ADR 0006: public, permalink-gated media reads (MediaModule exports MediaService).
+    MediaModule,
     forwardRef(() => PassportsModule),
     forwardRef(() => UniqueProductIdentifierModule),
     BrandingModule,
     PresentationConfigurationsModule,
   ],
-  controllers: [PermalinkController],
+  controllers: [PermalinkController, MediaPermalinkController],
   providers: [PermalinkRepository, PermalinkApplicationService],
   exports: [PermalinkRepository, PermalinkApplicationService],
 })

--- a/apps/main/src/permalink/presentation/media-permalink.controller.spec.ts
+++ b/apps/main/src/permalink/presentation/media-permalink.controller.spec.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, jest } from "@jest/globals";
+import { NotFoundException } from "@nestjs/common";
+import { File } from "../../aas/domain/submodel-base/file";
+import { MediaPermalinkController } from "./media-permalink.controller";
+
+function makePassport(submodelIds: string[]) {
+  return { getEnvironment: () => ({ submodels: submodelIds }) };
+}
+
+function submodelReferencing(mediaId: string) {
+  const file = File.create({ idShort: "doc", contentType: "application/pdf", value: mediaId });
+  return { getSubmodelElements: () => [file] };
+}
+
+function makeRes() {
+  const res: Record<string, unknown> = { headersSent: false };
+  res.setHeader = jest.fn();
+  res.status = jest.fn(() => res);
+  res.json = jest.fn(() => res);
+  return res as never;
+}
+
+function make(opts: { passport?: unknown; submodels?: Map<string, unknown> } = {}) {
+  const permalinkApplicationService = {
+    resolveToPassport: jest.fn<any>(async () => ({ passport: opts.passport ?? makePassport([]) })),
+  };
+  const mediaService = {
+    findOneOrFail: jest.fn<any>(async () => ({ id: "m-1" })),
+    getFilestreamById: jest.fn<any>(),
+  };
+  const submodelRepository = {
+    findByIds: jest.fn<any>(async () => opts.submodels ?? new Map()),
+  };
+  const controller = new MediaPermalinkController(
+    permalinkApplicationService as never,
+    mediaService as never,
+    submodelRepository as never,
+  );
+  return { controller, permalinkApplicationService, mediaService, submodelRepository };
+}
+
+describe("MediaPermalinkController (ADR 0006, Design C — membership)", () => {
+  it("getInfo serves a public projection of media the passport references (strips internals)", async () => {
+    const submodels = new Map([["sm-1", submodelReferencing("m-1")]]);
+    const { controller, mediaService, submodelRepository } = make({
+      passport: makePassport(["sm-1"]),
+      submodels,
+    });
+    mediaService.findOneOrFail.mockResolvedValue({
+      id: "m-1",
+      title: "doc.pdf",
+      mimeType: "application/pdf",
+      size: 42,
+      bucket: "secret-bucket",
+      objectName: "product-passport-files/abc",
+      ownedByOrganizationId: "org-1",
+      createdByUserId: "user-1",
+    });
+
+    const result = await controller.getInfo("slug-1", "m-1");
+
+    expect(submodelRepository.findByIds).toHaveBeenCalledWith(["sm-1"]);
+    expect(mediaService.findOneOrFail).toHaveBeenCalledWith("m-1");
+    // only the public MediaInfoDto fields — no bucket/objectName/org/user leakage
+    expect(result).toEqual({ id: "m-1", title: "doc.pdf", mimeType: "application/pdf", size: 42 });
+  });
+
+  it("getInfo 404s when the media is NOT referenced by the resolved passport (IDOR guard)", async () => {
+    const submodels = new Map([["sm-1", submodelReferencing("some-other-media")]]);
+    const { controller } = make({ passport: makePassport(["sm-1"]), submodels });
+    await expect(controller.getInfo("slug-1", "m-1")).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it("getInfo 404s when the permalink cannot be resolved (deleted/unpublished)", async () => {
+    const { controller, permalinkApplicationService } = make();
+    permalinkApplicationService.resolveToPassport.mockRejectedValue(new Error("not found"));
+    await expect(controller.getInfo("missing", "m-1")).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it("download streams a referenced media", async () => {
+    const submodels = new Map([["sm-1", submodelReferencing("m-1")]]);
+    const { controller, mediaService } = make({ passport: makePassport(["sm-1"]), submodels });
+    const pipe = jest.fn();
+    const on = jest.fn();
+    mediaService.getFilestreamById.mockResolvedValue({
+      media: { mimeType: "application/pdf", updatedAt: new Date() },
+      stream: { pipe, on },
+    });
+    const res = makeRes();
+
+    await controller.download("slug-1", "m-1", res);
+
+    expect(mediaService.getFilestreamById).toHaveBeenCalledWith("m-1");
+    expect(pipe).toHaveBeenCalledWith(res);
+  });
+
+  it("download 404s when the media is not referenced", async () => {
+    const submodels = new Map([["sm-1", submodelReferencing("other")]]);
+    const { controller } = make({ passport: makePassport(["sm-1"]), submodels });
+    const res = makeRes();
+    await controller.download("slug-1", "m-1", res);
+    expect((res as unknown as { status: jest.Mock }).status).toHaveBeenCalledWith(404);
+  });
+});

--- a/apps/main/src/permalink/presentation/media-permalink.controller.ts
+++ b/apps/main/src/permalink/presentation/media-permalink.controller.ts
@@ -1,0 +1,100 @@
+import type express from "express";
+import type { PublicMediaInfo } from "../../media/presentation/media-response.util";
+import type { Passport } from "../../passports/domain/passport";
+import { Controller, Get, NotFoundException, Param, Res } from "@nestjs/common";
+import { File } from "../../aas/domain/submodel-base/file";
+import { ISubmodelElement } from "../../aas/domain/submodel-base/submodel-base";
+import { SubmodelRepository } from "../../aas/infrastructure/submodel.repository";
+import { AllowAnonymous } from "../../identity/auth/presentation/decorators/allow-anonymous.decorator";
+import { MediaService } from "../../media/infrastructure/media.service";
+import { streamMedia, toPublicMediaInfo } from "../../media/presentation/media-response.util";
+import { PermalinkApplicationService } from "../application/services/permalink.application.service";
+
+/** Recursively collect every `File` element's `value` (a mediaId) under the given elements. */
+function collectFileMediaIds(elements: ISubmodelElement[], acc: Set<string>): void {
+  for (const element of elements) {
+    if (element instanceof File && element.value) {
+      acc.add(element.value);
+    }
+    collectFileMediaIds(element.getSubmodelElements(), acc);
+  }
+}
+
+/**
+ * Public, permalink-gated media access (ADR 0006, Design C).
+ *
+ * Media is reachable anonymously ONLY through a permalink, exactly like the rest of a
+ * passport's data: resolving the permalink applies the publish/ownership gate
+ * (`resolveToPassport`), and the requested media must be one of that passport's
+ * File-element values (the mediaId IS the passport↔media link — no denormalized field).
+ * So a deactivated/unpublished permalink 404s, and one passport's permalink cannot pull
+ * a media that the passport does not reference (no cross-passport IDOR). Many-to-many:
+ * a media shown on several passports is reachable through each of their permalinks.
+ *
+ * Routes are 5/6-segment (`media/permalink/:idOrSlug/by-id/:mediaId/...`) and never
+ * collide with the bare `media/:id/...` routes.
+ */
+@Controller("media")
+export class MediaPermalinkController {
+  constructor(
+    private readonly permalinkApplicationService: PermalinkApplicationService,
+    private readonly mediaService: MediaService,
+    private readonly submodelRepository: SubmodelRepository,
+  ) {}
+
+  @Get("permalink/:permalinkIdOrSlug/by-id/:mediaId/info")
+  @AllowAnonymous()
+  async getInfo(
+    @Param("permalinkIdOrSlug") permalinkIdOrSlug: string,
+    @Param("mediaId") mediaId: string,
+  ): Promise<PublicMediaInfo> {
+    await this.assertReferencedOr404(permalinkIdOrSlug, mediaId);
+    return toPublicMediaInfo(await this.mediaService.findOneOrFail(mediaId));
+  }
+
+  @Get("permalink/:permalinkIdOrSlug/by-id/:mediaId/download")
+  @AllowAnonymous()
+  async download(
+    @Param("permalinkIdOrSlug") permalinkIdOrSlug: string,
+    @Param("mediaId") mediaId: string,
+    @Res() res: express.Response,
+  ): Promise<void> {
+    try {
+      await this.assertReferencedOr404(permalinkIdOrSlug, mediaId);
+      const result = await this.mediaService.getFilestreamById(mediaId);
+      streamMedia(res, result.media, result.stream);
+    } catch {
+      res.status(404).json({ error: "File not found" });
+    }
+  }
+
+  /**
+   * Resolve the permalink to its passport (public publish/ownership gate) and assert the
+   * mediaId is one of that passport's File-element values. Anything else is a 404.
+   */
+  private async assertReferencedOr404(permalinkIdOrSlug: string, mediaId: string): Promise<void> {
+    let passport: Passport;
+    try {
+      ({ passport } = await this.permalinkApplicationService.resolveToPassport(permalinkIdOrSlug));
+    } catch {
+      throw new NotFoundException("Media not found");
+    }
+    if (!(await this.passportReferencesMedia(passport, mediaId))) {
+      throw new NotFoundException("Media not found");
+    }
+  }
+
+  /** Whether `mediaId` is referenced by a File element anywhere in the passport's submodels. */
+  private async passportReferencesMedia(passport: Passport, mediaId: string): Promise<boolean> {
+    const submodelIds = passport.getEnvironment().submodels;
+    if (submodelIds.length === 0) {
+      return false;
+    }
+    const submodels = await this.submodelRepository.findByIds(submodelIds);
+    const mediaIds = new Set<string>();
+    for (const submodel of submodels.values()) {
+      collectFileMediaIds(submodel.getSubmodelElements(), mediaIds);
+    }
+    return mediaIds.has(mediaId);
+  }
+}

--- a/packages/api-client/src/dpp/branding/branding.namespace.spec.ts
+++ b/packages/api-client/src/dpp/branding/branding.namespace.spec.ts
@@ -1,0 +1,22 @@
+import { BrandingNamespace } from "./branding.namespace";
+
+function makeNamespace() {
+  const get = jest.fn().mockResolvedValue({ data: new Blob() });
+  const put = jest.fn().mockResolvedValue({ data: {} });
+  const axios = { get, put } as any;
+  return { ns: new BrandingNamespace(axios), axios };
+}
+
+describe("BrandingNamespace", () => {
+  it("downloadLogo → GET /branding/logo/{mediaId} as a blob", async () => {
+    const { ns, axios } = makeNamespace();
+    await ns.downloadLogo("m-1");
+    expect(axios.get).toHaveBeenCalledWith("/branding/logo/m-1", { responseType: "blob" });
+  });
+
+  it("encodes the mediaId path segment", async () => {
+    const { ns, axios } = makeNamespace();
+    await ns.downloadLogo("a/b");
+    expect(axios.get).toHaveBeenCalledWith("/branding/logo/a%2Fb", { responseType: "blob" });
+  });
+});

--- a/packages/api-client/src/dpp/branding/branding.namespace.ts
+++ b/packages/api-client/src/dpp/branding/branding.namespace.ts
@@ -13,4 +13,15 @@ export class BrandingNamespace {
   public async set(branding: BrandingDto) {
     return await this.axiosInstance.put<BrandingDto>(this.brandingEndpoint, branding);
   }
+
+  /**
+   * Public, ownership-gated organization logo download. The bare `/media/:id` route is
+   * authenticated, so anonymous logo rendering goes through this branding-scoped route.
+   */
+  public async downloadLogo(mediaId: string) {
+    return await this.axiosInstance.get<Blob>(
+      `${this.brandingEndpoint}/logo/${encodeURIComponent(mediaId)}`,
+      { responseType: "blob" },
+    );
+  }
 }

--- a/packages/api-client/src/media/media.namespace.spec.ts
+++ b/packages/api-client/src/media/media.namespace.spec.ts
@@ -1,0 +1,24 @@
+import { MediaNamespace } from "./media.namespace";
+
+function makeNamespace() {
+  const get = jest.fn().mockResolvedValue({ data: {} });
+  const post = jest.fn().mockResolvedValue({ status: 201, data: { mediaId: "m-1" } });
+  const axios = { get, post } as any;
+  return { ns: new MediaNamespace(axios), axios };
+}
+
+describe("MediaNamespace — ADR 0006 (Design C) permalink-gated by-id routes", () => {
+  it("getPermalinkMediaInfo → GET /media/permalink/{idOrSlug}/by-id/{mediaId}/info", async () => {
+    const { ns, axios } = makeNamespace();
+    await ns.getPermalinkMediaInfo("slug-1", "m-1");
+    expect(axios.get).toHaveBeenCalledWith("/media/permalink/slug-1/by-id/m-1/info");
+  });
+
+  it("downloadPermalinkMedia → GET /media/permalink/{idOrSlug}/by-id/{mediaId}/download", async () => {
+    const { ns, axios } = makeNamespace();
+    await ns.downloadPermalinkMedia("slug-1", "m-1");
+    expect(axios.get).toHaveBeenCalledWith("/media/permalink/slug-1/by-id/m-1/download", {
+      responseType: "blob",
+    });
+  });
+});

--- a/packages/api-client/src/media/media.namespace.ts
+++ b/packages/api-client/src/media/media.namespace.ts
@@ -11,13 +11,6 @@ export class MediaNamespace {
     });
   }
 
-  async downloadMediaOfDataField(uuid: string, dataFieldId: string) {
-    return await this.axiosInstance.get<Blob>(
-      `${this.mediaEndpoint}/dpp/${uuid}/${dataFieldId}/download`,
-      { responseType: "blob" },
-    );
-  }
-
   async getMediaInfo(id: string) {
     return this.axiosInstance.get<MediaInfoDto>(`${this.mediaEndpoint}/${id}/info`);
   }
@@ -26,9 +19,20 @@ export class MediaNamespace {
     return this.axiosInstance.get<MediaInfoDto[]>(`${this.mediaEndpoint}/by-organization`);
   }
 
-  async getMediaInfoOfDataField(uuid: string, dataFieldId: string) {
+  // --- ADR 0006 (Design C): public file media gated through the permalink, by mediaId ---
+
+  /** Public, permalink-gated media info (access dies with the permalink). */
+  async getPermalinkMediaInfo(permalinkIdOrSlug: string, mediaId: string) {
     return this.axiosInstance.get<MediaInfoDto>(
-      `${this.mediaEndpoint}/dpp/${uuid}/${dataFieldId}/info`,
+      `${this.mediaEndpoint}/permalink/${encodeURIComponent(permalinkIdOrSlug)}/by-id/${encodeURIComponent(mediaId)}/info`,
+    );
+  }
+
+  /** Public, permalink-gated media download. */
+  async downloadPermalinkMedia(permalinkIdOrSlug: string, mediaId: string) {
+    return this.axiosInstance.get<Blob>(
+      `${this.mediaEndpoint}/permalink/${encodeURIComponent(permalinkIdOrSlug)}/by-id/${encodeURIComponent(mediaId)}/download`,
+      { responseType: "blob" },
     );
   }
 
@@ -37,16 +41,6 @@ export class MediaNamespace {
     onUploadProgress?: (progress: number) => void,
   ): Promise<string> {
     const url = `${this.mediaEndpoint}/organization-profile`;
-    return this.uploadMedia(url, file, onUploadProgress);
-  }
-
-  async uploadDppMedia(
-    uuid: string,
-    dataFieldId: string,
-    file: File,
-    onUploadProgress?: (progress: number) => void,
-  ): Promise<string> {
-    const url = `${this.mediaEndpoint}/dpp/${uuid}/${dataFieldId}`;
     return this.uploadMedia(url, file, onUploadProgress);
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,7 +65,7 @@ importers:
         version: 14.2.1(vue@3.5.32(typescript@5.9.3))
       axios:
         specifier: ^1.15.0
-        version: 1.15.0(debug@4.4.3)
+        version: 1.15.0
       better-auth:
         specifier: ^1.6.2
         version: 1.6.2(@opentelemetry/api@1.9.1)(mongodb@7.1.1)(vitest@4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(jsdom@27.4.0(@noble/hashes@2.2.0))(msw@2.13.3(@types/node@25.9.3)(typescript@5.9.3))(vite@7.3.2(@types/node@25.9.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3)))(vue@3.5.32(typescript@5.9.3))
@@ -300,7 +300,7 @@ importers:
         version: 7.0.1
       axios:
         specifier: ^1.15.0
-        version: 1.15.0(debug@4.4.3)
+        version: 1.15.0
       better-auth:
         specifier: ^1.6.2
         version: 1.6.2(@opentelemetry/api@1.9.1)(mongodb@7.1.1)(vitest@4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(jsdom@27.4.0(@noble/hashes@2.2.0))(msw@2.13.3(@types/node@25.9.3)(typescript@5.9.3))(vite@7.3.2(@types/node@25.9.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3)))(vue@3.5.32(typescript@5.9.3))
@@ -506,7 +506,7 @@ importers:
         version: link:../dto
       axios:
         specifier: ^1.15.0
-        version: 1.15.0(debug@4.4.3)
+        version: 1.15.0
     devDependencies:
       '@open-dpp/testing':
         specifier: workspace:*
@@ -9934,7 +9934,7 @@ snapshots:
   '@nestjs/axios@4.0.1(@nestjs/common@11.1.26(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(axios@1.15.0)(rxjs@7.8.2)':
     dependencies:
       '@nestjs/common': 11.1.26(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      axios: 1.15.0(debug@4.4.3)
+      axios: 1.15.0
       rxjs: 7.8.2
 
   '@nestjs/cli@11.0.19(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/node@25.9.3)':
@@ -11245,7 +11245,7 @@ snapshots:
       '@vueuse/shared': 14.2.1(vue@3.5.32(typescript@5.9.3))
       vue: 3.5.32(typescript@5.9.3)
     optionalDependencies:
-      axios: 1.15.0(debug@4.4.3)
+      axios: 1.15.0
       change-case: 5.4.4
       focus-trap: 7.8.0
       qrcode: 1.5.4
@@ -11681,7 +11681,7 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.1.0
 
-  axios@1.15.0(debug@4.4.3):
+  axios@1.15.0:
     dependencies:
       follow-redirects: 1.16.0(debug@4.4.3)
       form-data: 4.0.5


### PR DESCRIPTION
## Media keyed on permalinks + hardened media access — PR 3 of 3 (stacked)

**Base: `split/2-permalink-upi-core`** (review after PR 2). ADR 0006 — the media access-control re-key.

- Public media reads now resolve through a **membership-gated permalink** (`media-permalink.controller`); access dies with the permalink.
- Lock `/media/:id` down to authenticated + org-scoped; add a public, ownership-gated `/branding/logo/:id`.
- Remove the auto-minted canonical internal UPI; AI chat resolves the passport via the permalink instead of a canonical UPI.
- Wire `MediaModule` into the permalink and branding modules; drop the UPI dependency from the AI module.

### Test plan
- [x] `pnpm run build` — 8/8
- [x] api-client 121 · apps/main media/branding/ai + media-permalink + passport.controller — 107 tests
- [ ] CI green — rebase onto `main` before merge.
