### PR TITLE
fix(client): prevent blank page on invalid hex in primary color field

### DIFF
--- a/.changeset/fix-invalid-hex-blank-page.md
+++ b/.changeset/fix-invalid-hex-blank-page.md
@@ -1,0 +1,5 @@
+---
+"@open-dpp/client": patch
+---
+
+Fix blank page when entering an invalid hex value in the organization primary color field. The color palette now falls back to the default color for invalid input, the field shows an inline validation error, and saving is blocked until a valid hex color is entered.

--- a/apps/client/src/lib/color.spec.ts
+++ b/apps/client/src/lib/color.spec.ts
@@ -4,8 +4,36 @@ import {
   darkenHex,
   getContrastRatio,
   getPalettePositionByContrast,
+  isValidHexColor,
   lightenHex,
 } from "./color";
+
+describe("isValidHexColor", () => {
+  it("accepts 6-digit hex with and without leading #", () => {
+    expect(isValidHexColor("#336699")).toBe(true);
+    expect(isValidHexColor("336699")).toBe(true);
+  });
+
+  it("accepts 3-digit shorthand hex", () => {
+    expect(isValidHexColor("#abc")).toBe(true);
+    expect(isValidHexColor("abc")).toBe(true);
+  });
+
+  it("ignores surrounding whitespace", () => {
+    expect(isValidHexColor("  336699  ")).toBe(true);
+  });
+
+  it("rejects non-hex characters", () => {
+    expect(isValidHexColor("#zzzzzz")).toBe(false);
+    expect(isValidHexColor("xyz")).toBe(false);
+  });
+
+  it("rejects hex strings of the wrong length", () => {
+    expect(isValidHexColor("12")).toBe(false);
+    expect(isValidHexColor("1234")).toBe(false);
+    expect(isValidHexColor("")).toBe(false);
+  });
+});
 
 describe("getContrastRatio", () => {
   it("returns 21 for black and white", () => {

--- a/apps/client/src/lib/color.ts
+++ b/apps/client/src/lib/color.ts
@@ -1,12 +1,22 @@
-function hexToRgb(hex: string): { r: number; g: number; b: number } {
-  let normalized = hex.trim().replace(/^#/, "");
+function normalizeHex(hex: string): string {
+  const normalized = hex.trim().replace(/^#/, "");
 
   if (normalized.length === 3) {
-    normalized = normalized
+    return normalized
       .split("")
       .map((c) => c + c)
       .join("");
   }
+
+  return normalized;
+}
+
+function isValidHexColor(hex: string): boolean {
+  return /^[0-9a-f]{6}$/i.test(normalizeHex(hex));
+}
+
+function hexToRgb(hex: string): { r: number; g: number; b: number } {
+  const normalized = normalizeHex(hex);
 
   if (!/^[0-9a-f]{6}$/i.test(normalized)) {
     throw new Error(`Invalid hex color: ${hex}`);
@@ -131,5 +141,6 @@ export {
   darkenHex,
   getContrastRatio,
   getPalettePositionByContrast,
+  isValidHexColor,
   lightenHex,
 };

--- a/apps/client/src/translations/de-DE.json
+++ b/apps/client/src/translations/de-DE.json
@@ -407,7 +407,8 @@
       "color": {
         "label": "Primärfarbe",
         "palette": "Farbpalette",
-        "description": "Diese Farbe dient als Ausgangspunkt für die generierte Farbpalette."
+        "description": "Diese Farbe dient als Ausgangspunkt für die generierte Farbpalette.",
+        "error": "Bitte eine gültige Hex-Farbe eingeben (z. B. 6bad87)."
       },
       "permalinkBaseUrl": {
         "label": "Basis-URL für Produktpässe",

--- a/apps/client/src/translations/en-US.json
+++ b/apps/client/src/translations/en-US.json
@@ -407,7 +407,8 @@
       "color": {
         "label": "Primary color",
         "palette": "Color palette",
-        "description": "This color will be used as a base color to generate a color palette."
+        "description": "This color will be used as a base color to generate a color palette.",
+        "error": "Please enter a valid hex color (e.g. 6bad87)."
       },
       "permalinkBaseUrl": {
         "label": "Base URL for passports",

--- a/apps/client/src/view/organizations/OrganizationSettingsView.vue
+++ b/apps/client/src/view/organizations/OrganizationSettingsView.vue
@@ -29,8 +29,8 @@ const nameInvalid = ref(false);
 const { applyBranding } = useBranding();
 
 const colorInvalid = computed(() => {
-  const value = branding.value?.primaryColor;
-  return value != null && !isValidHexColor(value);
+  const value = branding.value?.primaryColor?.trim();
+  return value != null && value.length > 0 && !isValidHexColor(value);
 });
 
 const colorPalette = computed(() => {
@@ -67,7 +67,7 @@ async function save() {
     if (branding.value) {
       const brandingResult = await apiClient.dpp.branding.set({
         logo: branding.value.logo,
-        primaryColor: branding.value.primaryColor,
+        primaryColor: trimToNull(branding.value.primaryColor),
         permalinkBaseUrl: trimToNull(branding.value.permalinkBaseUrl),
       });
 

--- a/apps/client/src/view/organizations/OrganizationSettingsView.vue
+++ b/apps/client/src/view/organizations/OrganizationSettingsView.vue
@@ -30,7 +30,7 @@ const { applyBranding } = useBranding();
 
 const colorInvalid = computed(() => {
   const value = branding.value?.primaryColor;
-  return value != null && value.length > 0 && !isValidHexColor(value);
+  return value != null && !isValidHexColor(value);
 });
 
 const colorPalette = computed(() => {

--- a/apps/client/src/view/organizations/OrganizationSettingsView.vue
+++ b/apps/client/src/view/organizations/OrganizationSettingsView.vue
@@ -13,7 +13,7 @@ import { useErrorHandlingStore } from "../../stores/error.handling";
 import { useNotificationStore } from "../../stores/notification";
 import { useOrganizationsStore } from "../../stores/organizations";
 import ContentViewWrapper from "../ContentViewWrapper.vue";
-import { createColorPalette } from "../../lib/color";
+import { createColorPalette, isValidHexColor } from "../../lib/color";
 
 const defaultColor = "6bad87";
 
@@ -28,8 +28,15 @@ const branding = ref<BrandingDto | null>(null);
 const nameInvalid = ref(false);
 const { applyBranding } = useBranding();
 
+const colorInvalid = computed(() => {
+  const value = branding.value?.primaryColor;
+  return value != null && value.length > 0 && !isValidHexColor(value);
+});
+
 const colorPalette = computed(() => {
-  return createColorPalette(branding.value?.primaryColor ?? defaultColor);
+  const value = branding.value?.primaryColor;
+  const hex = value && isValidHexColor(value) ? value : defaultColor;
+  return createColorPalette(hex);
 });
 
 function trimToNull(value: string | null | undefined): string | null {
@@ -39,6 +46,10 @@ function trimToNull(value: string | null | undefined): string | null {
 }
 
 async function save() {
+  if (colorInvalid.value) {
+    notificationStore.addErrorNotification(t("organizations.form.color.error"));
+    return;
+  }
   try {
     let updatedSettings = false;
     if (organization.value && indexStore.selectedOrganization) {
@@ -117,7 +128,7 @@ onMounted(async () => {
               id="color"
               v-model="branding.primaryColor"
               :default-color="defaultColor"
-              :invalid="nameInvalid"
+              :invalid="colorInvalid"
             />
             <InputGroup>
               <InputGroupAddon>#</InputGroupAddon>
@@ -127,7 +138,7 @@ onMounted(async () => {
                 maxlength="6"
                 inputmode="text"
                 :placeholder="defaultColor"
-                :invalid="nameInvalid"
+                :invalid="colorInvalid"
               />
             </InputGroup>
             <Button
@@ -138,6 +149,9 @@ onMounted(async () => {
               {{ t("common.reset") }}
             </Button>
           </div>
+          <small v-if="colorInvalid" class="text-red-500">{{
+            t("organizations.form.color.error")
+          }}</small>
         </div>
         <div class="flex flex-col gap-2">
           <label for="color" class="block text-sm leading-6 font-medium text-gray-900">{{


### PR DESCRIPTION
The organization settings color palette computed called createColorPalette, which throws on invalid hex. Thrown from a render-time computed, this crashed the component tree and blanked the page while typing.

- Add isValidHexColor() to lib/color (keeps the existing throwing contract)
- Fall back to the default color for invalid input in the palette preview
- Show an inline validation error and block save on invalid hex
- Fix color inputs previously bound to the unrelated nameInvalid flag
- Add unit tests + en/de translations

Closes #654

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented blank pages when an invalid organization branding color is entered.
  * Added inline validation for primary colors, with clear guidance for valid hex values.
  * Prevented saving organization settings until the color value is valid.
  * Invalid values now fall back to the default color instead of breaking the page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->