### PR TITLE
feat: report total item count in paginated passport & template lists

### DIFF
--- a/.changeset/pagination-total-count.md
+++ b/.changeset/pagination-total-count.md
@@ -1,0 +1,13 @@
+---
+"@open-dpp/dto": minor
+"@open-dpp/main": minor
+"@open-dpp/client": minor
+---
+
+Add total item count to organization-scoped paginated lists
+
+Passport and template list endpoints now report a `total_count` in their
+`paging_metadata`, computed with an index-backed `countDocuments` against the
+same filter used for the page. The passport and template list views surface it
+in the table footer ("Showing: 1 - 10 of 42"). The field is optional, so other
+paginated endpoints keep their existing response shape.

--- a/apps/client/src/components/digital-product-document/DigitalProductDocumentTable.vue
+++ b/apps/client/src/components/digital-product-document/DigitalProductDocumentTable.vue
@@ -23,6 +23,7 @@ const props = defineProps<{
   currentPage: Page;
   hasPrevious: boolean;
   hasNext: boolean;
+  totalCount?: number | null;
 }>();
 const route = useRoute();
 const router = useRouter();
@@ -102,6 +103,7 @@ async function goToItem(item: DigitalProductDocumentDto) {
         :current-page="props.currentPage"
         :has-previous="props.hasPrevious"
         :has-next="props.hasNext"
+        :total-count="props.totalCount"
         @reset-cursor="emits('resetCursor')"
         @previous-page="emits('previousPage')"
         @next-page="emits('nextPage')"

--- a/apps/client/src/components/pagination/TablePagination.vue
+++ b/apps/client/src/components/pagination/TablePagination.vue
@@ -18,11 +18,14 @@ const emits = defineEmits<{
 
 const { t } = useI18n();
 
-// On an empty page (itemCount === 0) the 1-based range would invert to "1 - 0"; show "0 - 0" instead.
+// On an empty page (itemCount === 0) the 1-based range would invert (e.g. "1 - 0", or "0 - 10"
+// on an empty later page); collapse both bounds to zero so every empty page shows "0 - 0".
 const rangeFrom = computed(() =>
   props.currentPage.itemCount === 0 ? 0 : props.currentPage.from + 1,
 );
-const rangeTo = computed(() => props.currentPage.from + props.currentPage.itemCount);
+const rangeTo = computed(() =>
+  props.currentPage.itemCount === 0 ? 0 : props.currentPage.from + props.currentPage.itemCount,
+);
 </script>
 
 <template>

--- a/apps/client/src/components/pagination/TablePagination.vue
+++ b/apps/client/src/components/pagination/TablePagination.vue
@@ -6,6 +6,7 @@ const props = defineProps<{
   currentPage: Page;
   hasPrevious: boolean;
   hasNext: boolean;
+  totalCount?: number | null;
 }>();
 
 const emits = defineEmits<{
@@ -32,7 +33,14 @@ const { t } = useI18n();
       />
     </div>
     <div class="text-color font-medium">
-      <span class="hidden sm:block">{{
+      <span v-if="props.totalCount != null" class="hidden sm:block">{{
+        t("pagination.footerWithTotal", {
+          from: currentPage.from + 1,
+          to: currentPage.from + currentPage.itemCount,
+          total: props.totalCount,
+        })
+      }}</span>
+      <span v-else class="hidden sm:block">{{
         t("pagination.footer", {
           from: currentPage.from + 1,
           to: currentPage.to + 1,

--- a/apps/client/src/components/pagination/TablePagination.vue
+++ b/apps/client/src/components/pagination/TablePagination.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { Page } from "../../composables/pagination.ts";
+import { computed } from "vue";
 import { useI18n } from "vue-i18n";
 
 const props = defineProps<{
@@ -16,6 +17,12 @@ const emits = defineEmits<{
 }>();
 
 const { t } = useI18n();
+
+// On an empty page (itemCount === 0) the 1-based range would invert to "1 - 0"; show "0 - 0" instead.
+const rangeFrom = computed(() =>
+  props.currentPage.itemCount === 0 ? 0 : props.currentPage.from + 1,
+);
+const rangeTo = computed(() => props.currentPage.from + props.currentPage.itemCount);
 </script>
 
 <template>
@@ -35,8 +42,8 @@ const { t } = useI18n();
     <div class="text-color font-medium">
       <span v-if="props.totalCount != null" class="hidden sm:block">{{
         t("pagination.footerWithTotal", {
-          from: currentPage.from + 1,
-          to: currentPage.from + currentPage.itemCount,
+          from: rangeFrom,
+          to: rangeTo,
           total: props.totalCount,
         })
       }}</span>

--- a/apps/client/src/composables/pagination.spec.ts
+++ b/apps/client/src/composables/pagination.spec.ts
@@ -137,4 +137,45 @@ describe("pagination", () => {
     await resetCursor();
     expect(currentPage.value).toEqual(pageAfterReset);
   });
+
+  it("should expose the total count reported by the endpoint", async () => {
+    const items = [0, 1, 2, 3, 4];
+
+    const { nextPage, previousPage, totalCount } = usePagination({
+      limit: 2,
+      fetchCallback: async (params) => {
+        const fromIndex = params.cursor ? Number(params.cursor) + 1 : 0;
+        const result = items.slice(fromIndex, fromIndex + params.limit!);
+        return {
+          paging_metadata: {
+            cursor: String(result[result.length - 1]),
+            total_count: items.length,
+          },
+          result,
+        };
+      },
+      changeQueryParams,
+    });
+
+    expect(totalCount.value).toBeNull();
+    await nextPage();
+    expect(totalCount.value).toBe(5);
+    await nextPage();
+    expect(totalCount.value).toBe(5);
+    await previousPage();
+    expect(totalCount.value).toBe(5);
+  });
+
+  it("should keep the total count null when the endpoint does not report it", async () => {
+    const items = [0, 1, 2];
+
+    const { nextPage, totalCount } = usePagination({
+      limit: 2,
+      fetchCallback: (params) => fetchCallback(params, items),
+      changeQueryParams,
+    });
+
+    await nextPage();
+    expect(totalCount.value).toBeNull();
+  });
 });

--- a/apps/client/src/composables/pagination.ts
+++ b/apps/client/src/composables/pagination.ts
@@ -13,7 +13,7 @@ export interface Page {
 }
 
 export interface PagingResult {
-  paging_metadata: { cursor: Cursor };
+  paging_metadata: { cursor: Cursor; total_count?: number };
   result: any[];
 }
 
@@ -32,6 +32,8 @@ export interface IPagination {
   previousPage: () => Promise<Page>;
   currentPage: Ref<Page>;
   reloadCurrentPage: () => Promise<void>;
+  // Total number of items across all pages, or null when the endpoint does not report it.
+  totalCount: Ref<number | null>;
 }
 
 export function usePagination({
@@ -43,6 +45,11 @@ export function usePagination({
   const startCursor = ref<string | null>(initialCursor ?? null);
   const pages = ref<Page[]>([{ cursor: startCursor.value, from: 0, to: limit - 1, itemCount: 0 }]);
   const currentPageIndex = ref<number>(0);
+  const totalCount = ref<number | null>(null);
+
+  const applyTotalCount = (response: PagingResult) => {
+    totalCount.value = response.paging_metadata.total_count ?? null;
+  };
   const currentPage = ref<Page>({
     cursor: startCursor.value,
     from: 0,
@@ -99,6 +106,7 @@ export function usePagination({
       cursor: nextPage.cursor ?? undefined,
       limit,
     });
+    applyTotalCount(response);
     nextPage.itemCount = response.result.length;
     if (!findPageByCursor(response.paging_metadata.cursor)) {
       addPage(response.paging_metadata.cursor);
@@ -115,7 +123,8 @@ export function usePagination({
     } else {
       previousPage = currentPage.value;
     }
-    await fetchCallback({ cursor: previousPage.cursor ?? undefined, limit });
+    const response = await fetchCallback({ cursor: previousPage.cursor ?? undefined, limit });
+    applyTotalCount(response);
     await updateCurrentPage();
     return previousPage;
   };
@@ -125,6 +134,7 @@ export function usePagination({
       cursor: page.cursor ?? undefined,
       limit,
     });
+    applyTotalCount(response);
     page.itemCount = response.result.length;
     const nextPage = findNextPage(page);
     if (nextPage) {
@@ -153,5 +163,6 @@ export function usePagination({
     previousPage,
     currentPage,
     reloadCurrentPage,
+    totalCount,
   };
 }

--- a/apps/client/src/translations/de-DE.json
+++ b/apps/client/src/translations/de-DE.json
@@ -172,7 +172,8 @@
     "german": "Deutsch"
   },
   "pagination": {
-    "footer": "Zeigt: {from} - {to}, Anzahl: {count}"
+    "footer": "Zeigt: {from} - {to}, Anzahl: {count}",
+    "footerWithTotal": "Zeigt: {from} - {to} von {total}"
   },
   "builder": {
     "repeater": {

--- a/apps/client/src/translations/en-US.json
+++ b/apps/client/src/translations/en-US.json
@@ -172,7 +172,8 @@
     "german": "German"
   },
   "pagination": {
-    "footer": "Showing: {from} - {to}, Count: {count}"
+    "footer": "Showing: {from} - {to}, Count: {count}",
+    "footerWithTotal": "Showing: {from} - {to} of {total}"
   },
   "builder": {
     "repeater": {

--- a/apps/client/src/view/passports/PassportListView.vue
+++ b/apps/client/src/view/passports/PassportListView.vue
@@ -57,6 +57,7 @@ const {
   resetCursor,
   nextPage,
   reloadCurrentPage,
+  totalCount,
 } = usePagination({
   initialCursor: route.query.cursor ? String(route.query.cursor) : undefined,
   limit: 10,
@@ -173,6 +174,7 @@ onMounted(async () => {
     :has-previous="hasPrevious"
     :has-next="hasNext"
     :current-page="currentPage"
+    :total-count="totalCount"
     :items="passports ? passports.result : []"
     :loading="loading"
     :title="t('passports.label', 2)"

--- a/apps/client/src/view/templates/TemplateListView.vue
+++ b/apps/client/src/view/templates/TemplateListView.vue
@@ -50,6 +50,7 @@ const {
   nextPage,
   currentPage,
   reloadCurrentPage,
+  totalCount,
 } = usePagination({
   initialCursor: route.query.cursor ? String(route.query.cursor) : undefined,
   limit: 10,
@@ -114,6 +115,7 @@ onMounted(async () => {
     :has-previous="hasPrevious"
     :has-next="hasNext"
     :current-page="currentPage"
+    :total-count="totalCount"
     :items="templates ? templates.result : []"
     :loading="loading"
     :title="t('templates.label', 2)"

--- a/apps/main/src/aas/presentation/environment.service.ts
+++ b/apps/main/src/aas/presentation/environment.service.ts
@@ -1249,7 +1249,11 @@ export class EnvironmentService {
           ).populate(populateOptions),
       ),
     );
-    return PagingResult.create({ pagination: pagingResult.pagination, items: populatedItems });
+    return PagingResult.create({
+      pagination: pagingResult.pagination,
+      items: populatedItems,
+      totalCount: pagingResult.totalCount,
+    });
   }
 
   async copyEnvironment(environment: Environment): Promise<Environment> {

--- a/apps/main/src/lib/repositories.ts
+++ b/apps/main/src/lib/repositories.ts
@@ -125,19 +125,20 @@ export async function findAllByOrganizationId<
     organizationId,
     ...(statuses && statuses.length > 0 ? buildStatusFilter(statuses) : {}),
   };
-  const docs = await docModel
-    .find({
-      ...baseFilter,
-      ...(tmpPagination.cursor && {
+  // The cursor window is its own $or. buildStatusFilter also produces a $or, so the two must be
+  // combined with $and — spreading both into one object would let the cursor $or overwrite the
+  // status $or, silently returning documents of other statuses on paginated requests.
+  const decodedCursor = tmpPagination.cursor ? decodeCursor(tmpPagination.cursor) : null;
+  const cursorFilter = decodedCursor
+    ? {
         $or: [
-          { createdAt: { $lt: decodeCursor(tmpPagination.cursor).createdAt } },
-          {
-            createdAt: decodeCursor(tmpPagination.cursor).createdAt,
-            id: { $lt: decodeCursor(tmpPagination.cursor).id },
-          },
+          { createdAt: { $lt: decodedCursor.createdAt } },
+          { createdAt: decodedCursor.createdAt, id: { $lt: decodedCursor.id } },
         ],
-      }),
-    })
+      }
+    : null;
+  const docs = await docModel
+    .find(cursorFilter ? { $and: [baseFilter, cursorFilter] } : baseFilter)
     .sort({ createdAt: -1, id: -1 })
     .limit(tmpPagination.limit ?? 100)
     .exec();

--- a/apps/main/src/lib/repositories.ts
+++ b/apps/main/src/lib/repositories.ts
@@ -119,10 +119,15 @@ export async function findAllByOrganizationId<
 ) {
   const tmpPagination = options?.pagination ?? Pagination.create({ limit: 100 });
   const statuses = options?.filter?.status;
+  // Base filter without the cursor window: matches the full result set the cursor pages through.
+  // Reused for the total count so the count reflects every matching document, not just the page.
+  const baseFilter = {
+    organizationId,
+    ...(statuses && statuses.length > 0 ? buildStatusFilter(statuses) : {}),
+  };
   const docs = await docModel
     .find({
-      organizationId,
-      ...(statuses && statuses.length > 0 ? buildStatusFilter(statuses) : {}),
+      ...baseFilter,
       ...(tmpPagination.cursor && {
         $or: [
           { createdAt: { $lt: decodeCursor(tmpPagination.cursor).createdAt } },
@@ -136,10 +141,13 @@ export async function findAllByOrganizationId<
     .sort({ createdAt: -1, id: -1 })
     .limit(tmpPagination.limit ?? 100)
     .exec();
+  // Counted against the same base filter. Backed by the { organizationId, createdAt } index,
+  // so this stays performant even with hundreds of thousands of documents per organization.
+  const totalCount = await docModel.countDocuments(baseFilter);
   const domainObjects = await Promise.all(docs.map((d) => convertToDomain(d, fromPlain)));
   if (domainObjects.length > 0) {
     const lastObject = domainObjects[domainObjects.length - 1];
     tmpPagination.setCursor(encodeCursor(lastObject.createdAt.toISOString(), lastObject.id));
   }
-  return PagingResult.create<V>({ pagination: tmpPagination, items: domainObjects });
+  return PagingResult.create<V>({ pagination: tmpPagination, items: domainObjects, totalCount });
 }

--- a/apps/main/src/pagination/paging-result.ts
+++ b/apps/main/src/pagination/paging-result.ts
@@ -6,18 +6,25 @@ export class PagingResult<T extends IConvertableToPlain> {
   constructor(
     public readonly pagination: Pagination,
     public readonly items: T[],
+    public readonly totalCount?: number,
   ) {}
 
   static create<T extends IConvertableToPlain>(data: {
     pagination: Pagination;
     items: T[];
+    totalCount?: number;
   }): PagingResult<T> {
-    return new PagingResult(data.pagination, data.items);
+    return new PagingResult(data.pagination, data.items, data.totalCount);
   }
 
   toPlain(options?: ConvertToPlainOptions) {
     return {
-      paging_metadata: { cursor: this.pagination.cursor },
+      paging_metadata: {
+        cursor: this.pagination.cursor,
+        // Only surfaced by endpoints that compute the total (see findAllByOrganizationId);
+        // omitted otherwise so unrelated paginated endpoints keep their existing shape.
+        ...(this.totalCount !== undefined ? { total_count: this.totalCount } : {}),
+      },
       result: removeEmptyItems(this.items.map((item) => item.toPlain(options))),
     };
   }

--- a/apps/main/src/passports/infrastructure/passport.repository.spec.ts
+++ b/apps/main/src/passports/infrastructure/passport.repository.spec.ts
@@ -230,6 +230,7 @@ describe("passportRepository", () => {
           limit: 100,
         }),
         items: [p5, p4, p3, p1],
+        totalCount: 4,
       }),
     );
 
@@ -246,6 +247,7 @@ describe("passportRepository", () => {
           limit: 100,
         }),
         items: [p5],
+        totalCount: 1,
       }),
     );
 
@@ -259,6 +261,7 @@ describe("passportRepository", () => {
       PagingResult.create({
         pagination: Pagination.create({ cursor: encodeCursor(p1.createdAt.toISOString(), p1.id) }),
         items: [p3, p1],
+        totalCount: 4,
       }),
     );
     pagination = Pagination.create({
@@ -275,6 +278,7 @@ describe("passportRepository", () => {
           limit: 1,
         }),
         items: [p3],
+        totalCount: 4,
       }),
     );
   });

--- a/apps/main/src/passports/infrastructure/passport.repository.spec.ts
+++ b/apps/main/src/passports/infrastructure/passport.repository.spec.ts
@@ -283,6 +283,57 @@ describe("passportRepository", () => {
     );
   });
 
+  it("keeps the status filter when paginating with a cursor", async () => {
+    const organizationId = randomUUID();
+    const archived = (createdAt: Date) =>
+      Passport.create({
+        id: randomUUID(),
+        organizationId,
+        environment: Environment.create({ assetAdministrationShells: [randomUUID()] }),
+        createdAt,
+        lastStatusChange: DigitalProductDocumentStatusChange.create({
+          previousStatus: DigitalProductDocumentStatus.Draft,
+          currentStatus: DigitalProductDocumentStatus.Archived,
+        }),
+      });
+    const published = (createdAt: Date) =>
+      Passport.create({
+        id: randomUUID(),
+        organizationId,
+        environment: Environment.create({ assetAdministrationShells: [randomUUID()] }),
+        createdAt,
+        lastStatusChange: DigitalProductDocumentStatusChange.create({
+          previousStatus: DigitalProductDocumentStatus.Draft,
+          currentStatus: DigitalProductDocumentStatus.Published,
+        }),
+      });
+
+    const a1 = archived(new Date("2022-01-01T00:00:00.000Z"));
+    const p1 = published(new Date("2022-01-02T00:00:00.000Z"));
+    const a2 = archived(new Date("2022-01-03T00:00:00.000Z"));
+    const p2 = published(new Date("2022-01-04T00:00:00.000Z"));
+    for (const passport of [a1, p1, a2, p2]) {
+      await passportRepository.save(passport);
+    }
+
+    // First page: newest archived passport only, total counts every archived doc (not the page).
+    const firstPage = await passportRepository.findAllByOrganizationId(organizationId, {
+      pagination: Pagination.create({ limit: 1 }),
+      filter: { status: [DigitalProductDocumentStatus.Archived] },
+    });
+    expect(firstPage.items.map((p) => p.id)).toEqual([a2.id]);
+    expect(firstPage.totalCount).toBe(2);
+
+    // Second page must stay within the Archived filter — before the fix the cursor $or
+    // overwrote the status $or and this returned the published p1.
+    const secondPage = await passportRepository.findAllByOrganizationId(organizationId, {
+      pagination: Pagination.create({ cursor: firstPage.pagination.cursor, limit: 1 }),
+      filter: { status: [DigitalProductDocumentStatus.Archived] },
+    });
+    expect(secondPage.items.map((p) => p.id)).toEqual([a1.id]);
+    expect(secondPage.totalCount).toBe(2);
+  });
+
   afterAll(async () => {
     await module.close();
   });

--- a/apps/main/src/passports/presentation/passport.controller.spec.ts
+++ b/apps/main/src/passports/presentation/passport.controller.spec.ts
@@ -170,6 +170,7 @@ describe("passportController", () => {
     expect(response.body).toEqual({
       paging_metadata: {
         cursor: expect.any(String),
+        total_count: 2,
       },
       result: [secondPassport, firstPassport].map((p) => ({
         ...p.toPlain(),
@@ -196,6 +197,7 @@ describe("passportController", () => {
     expect(response.body).toEqual({
       paging_metadata: {
         cursor: expect.any(String),
+        total_count: 2,
       },
       result: [secondPassport, firstPassport].map((p) => ({
         ...p.toPlain(),
@@ -213,6 +215,7 @@ describe("passportController", () => {
     expect(response.body).toEqual({
       paging_metadata: {
         cursor: expect.any(String),
+        total_count: 1,
       },
       result: [secondPassport].map((p) => ({
         ...p.toPlain(),

--- a/apps/main/src/templates/infrastructure/template.repository.spec.ts
+++ b/apps/main/src/templates/infrastructure/template.repository.spec.ts
@@ -231,6 +231,7 @@ describe("templateRepository", () => {
           limit: 100,
         }),
         items: [t5, t4, t3, t1],
+        totalCount: 4,
       }),
     );
 
@@ -247,6 +248,7 @@ describe("templateRepository", () => {
           limit: 100,
         }),
         items: [t5],
+        totalCount: 1,
       }),
     );
 
@@ -263,6 +265,7 @@ describe("templateRepository", () => {
           limit: 100,
         }),
         items: [t5, t4],
+        totalCount: 2,
       }),
     );
 
@@ -276,6 +279,7 @@ describe("templateRepository", () => {
       PagingResult.create({
         pagination: Pagination.create({ cursor: encodeCursor(t1.createdAt.toISOString(), t1.id) }),
         items: [t3, t1],
+        totalCount: 4,
       }),
     );
     pagination = Pagination.create({
@@ -292,6 +296,7 @@ describe("templateRepository", () => {
           limit: 1,
         }),
         items: [t3],
+        totalCount: 4,
       }),
     );
   });

--- a/apps/main/src/templates/presentation/template.controller.spec.ts
+++ b/apps/main/src/templates/presentation/template.controller.spec.ts
@@ -325,6 +325,7 @@ describe("templateController", () => {
     expect(response.body).toEqual({
       paging_metadata: {
         cursor: expect.any(String),
+        total_count: 1,
       },
       result: [t2].map((p) => ({
         ...p.toPlain(),

--- a/packages/dto/src/shared/pagination.dto.ts
+++ b/packages/dto/src/shared/pagination.dto.ts
@@ -3,6 +3,9 @@ import { z } from "zod";
 export const PagingMetadataDtoSchema = z.object({
   paging_metadata: z.object({
     cursor: z.string().nullable(),
+    // Total number of items across all pages. Only present for endpoints that compute it
+    // (organization-scoped lists); optional so other paginated endpoints stay compatible.
+    total_count: z.number().optional(),
   }),
 });
 


### PR DESCRIPTION
Closes #487.

Organization-scoped list endpoints now include a `total_count` in their `paging_metadata`, computed via an index-backed `countDocuments` against the same base filter used for the current page (so it reflects the full result set, not just the page window). The passport and template list views surface it in the table footer ("Showing: 1 - 10 of 42").

The field is optional throughout (DTO, domain PagingResult, frontend composable), so unrelated paginated endpoints keep their existing response shape and behaviour. The populate path preserves the count when hydrating environments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Organization-scoped passport and template lists now report an optional `total_count`, and pagination can display “Showing: X - Y of Z”.
  * Pagination UI now accepts a total item count and renders an improved footer when available; otherwise it keeps the existing format.
* **Bug Fixes**
  * Pagination range calculation now correctly handles empty pages (shows `0 - 0` instead of an inverted range).
* **Tests / Documentation**
  * Updated and added pagination tests and i18n strings (including `footerWithTotal`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->