### PR TITLE
refactor(email-templates): remove footer text '&mdash; open-dpp'

### DIFF
--- a/.changeset/smart-kiwis-teach.md
+++ b/.changeset/smart-kiwis-teach.md
@@ -1,0 +1,5 @@
+---
+"@open-dpp/main": patch
+---
+
+Simplified email footers

--- a/apps/main/src/email/templates/base-text-and-link.mjml
+++ b/apps/main/src/email/templates/base-text-and-link.mjml
@@ -23,14 +23,6 @@
           font-size="16px"
           >{{ actionText }}</mj-button
         >
-        <mj-text
-          align="center"
-          color="#000000"
-          font-size="14px"
-          font-family="Arial, sans-serif"
-          padding-top="40px"
-          >open-dpp GmbH</mj-text
-        >
       </mj-column>
     </mj-section>
   </mj-body>

--- a/apps/main/src/email/templates/email-change-completed-de.mjml
+++ b/apps/main/src/email/templates/email-change-completed-de.mjml
@@ -18,14 +18,6 @@
           >Falls du das nicht warst, kontaktiere bitte sofort den Support. Deine vorherige
           E-Mail-Adresse k&ouml;nnte kompromittiert sein.</mj-text
         >
-        <mj-text
-          align="center"
-          color="#000000"
-          font-size="14px"
-          font-family="Arial, sans-serif"
-          padding-top="40px"
-          >&mdash; open-dpp</mj-text
-        >
       </mj-column>
     </mj-section>
   </mj-body>

--- a/apps/main/src/email/templates/email-change-completed.mjml
+++ b/apps/main/src/email/templates/email-change-completed.mjml
@@ -19,14 +19,6 @@
           >If this wasn&rsquo;t you, contact support immediately. Your previous email may be
           compromised.</mj-text
         >
-        <mj-text
-          align="center"
-          color="#000000"
-          font-size="14px"
-          font-family="Arial, sans-serif"
-          padding-top="40px"
-          >&mdash; open-dpp</mj-text
-        >
       </mj-column>
     </mj-section>
   </mj-body>

--- a/apps/main/src/email/templates/email-change-notification-de.mjml
+++ b/apps/main/src/email/templates/email-change-notification-de.mjml
@@ -34,14 +34,6 @@
           font-size="16px"
           >E-Mail-&Auml;nderung abbrechen</mj-button
         >
-        <mj-text
-          align="center"
-          color="#000000"
-          font-size="14px"
-          font-family="Arial, sans-serif"
-          padding-top="40px"
-          >&mdash; open-dpp</mj-text
-        >
       </mj-column>
     </mj-section>
   </mj-body>

--- a/apps/main/src/email/templates/email-change-notification.mjml
+++ b/apps/main/src/email/templates/email-change-notification.mjml
@@ -35,14 +35,6 @@
           font-size="16px"
           >Cancel email change</mj-button
         >
-        <mj-text
-          align="center"
-          color="#000000"
-          font-size="14px"
-          font-family="Arial, sans-serif"
-          padding-top="40px"
-          >&mdash; open-dpp</mj-text
-        >
       </mj-column>
     </mj-section>
   </mj-body>

--- a/apps/main/src/email/templates/email-change-verification-de.mjml
+++ b/apps/main/src/email/templates/email-change-verification-de.mjml
@@ -31,14 +31,6 @@
           >Falls du diese &Auml;nderung nicht angefordert hast, kannst du diese Nachricht ignorieren
           &mdash; deine Konto-E-Mail-Adresse bleibt dann unver&auml;ndert.</mj-text
         >
-        <mj-text
-          align="center"
-          color="#000000"
-          font-size="14px"
-          font-family="Arial, sans-serif"
-          padding-top="40px"
-          >&mdash; open-dpp</mj-text
-        >
       </mj-column>
     </mj-section>
   </mj-body>

--- a/apps/main/src/email/templates/email-change-verification.mjml
+++ b/apps/main/src/email/templates/email-change-verification.mjml
@@ -32,14 +32,6 @@
           >If you did not request this change, you can safely ignore this message and your account
           email will stay the same.</mj-text
         >
-        <mj-text
-          align="center"
-          color="#000000"
-          font-size="14px"
-          font-family="Arial, sans-serif"
-          padding-top="40px"
-          >&mdash; open-dpp</mj-text
-        >
       </mj-column>
     </mj-section>
   </mj-body>

--- a/apps/main/src/email/templates/email-verify.mjml
+++ b/apps/main/src/email/templates/email-verify.mjml
@@ -26,14 +26,6 @@
           font-size="16px"
           >Verify email</mj-button
         >
-        <mj-text
-          align="center"
-          color="#000000"
-          font-size="14px"
-          font-family="Arial, sans-serif"
-          padding-top="40px"
-          >open-dpp GmbH</mj-text
-        >
       </mj-column>
     </mj-section>
   </mj-body>

--- a/apps/main/src/email/templates/invite-user-to-organization.mjml
+++ b/apps/main/src/email/templates/invite-user-to-organization.mjml
@@ -26,14 +26,6 @@
           font-size="16px"
           >Join organization</mj-button
         >
-        <mj-text
-          align="center"
-          color="#000000"
-          font-size="14px"
-          font-family="Arial, sans-serif"
-          padding-top="40px"
-          >open-dpp GmbH</mj-text
-        >
       </mj-column>
     </mj-section>
   </mj-body>


### PR DESCRIPTION
This pull request removes the footer text (such as "open-dpp GmbH" or "— open-dpp") from several email templates. The intent is to simplify the email layout by omitting the company signature or footer line from the bottom of these templates.

**Email template simplification:**

* Removed the footer text ("open-dpp GmbH" or "— open-dpp") from the following templates:
  - `base-text-and-link.mjml`
  - `email-verify.mjml`
  - `invite-user-to-organization.mjml`
  - `email-change-completed.mjml`
  - `email-change-completed-de.mjml`
  - `email-change-notification.mjml`
  - `email-change-notification-de.mjml`
  - `email-change-verification.mjml`
  - `email-change-verification-de.mjml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Simplified email footers by removing company attribution text from verification, change notification, change confirmation, and invitation emails.
  * Applied the updated footer style consistently across English and German email templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->