### PR TITLE
refactor(permalinks): remove presentation configuration select field

### DIFF
--- a/.changeset/goofy-files-lose.md
+++ b/.changeset/goofy-files-lose.md
@@ -1,0 +1,5 @@
+---
+"@open-dpp/client": patch
+---
+
+Removed select field for presentation configuration on permalinks as presentation configurations canot be managed at the moment.

--- a/apps/client/src/components/permalinks/PermalinkCreateDialog.vue
+++ b/apps/client/src/components/permalinks/PermalinkCreateDialog.vue
@@ -29,7 +29,6 @@ const { t } = useI18n();
 const errorHandlingStore = useErrorHandlingStore();
 
 const selectedUpiId = ref<string | undefined>(props.preselectedUpiId);
-const selectedConfigId = ref<string | undefined>(undefined);
 const slug = ref<string>("");
 const baseUrl = ref<string>("");
 const gs1DataAttributes = ref<Record<string, string>>({});
@@ -56,10 +55,6 @@ function upiLabel(upi: UniqueProductIdentifierListItemDto): string {
     return parts.length > 0 ? parts.join(" / ") : upi.uuid;
   }
   return upi.uuid;
-}
-
-function configLabel(config: PresentationConfigurationDto): string {
-  return config.label ?? config.id;
 }
 
 watch(
@@ -93,7 +88,8 @@ async function submit() {
           kind: PermalinkKind.OPEN_DPP,
           passportId: props.passportId,
           uniqueProductIdentifierId: selectedUpiId.value ?? null,
-          presentationConfigurationId: selectedConfigId.value ?? null,
+          // ponytail: config select hidden (#684) — auto-target last created config
+          presentationConfigurationId: props.configs.at(-1)?.id ?? null,
           slug: trimToNull(slug.value),
           baseUrl: trimToNull(baseUrl.value),
         };
@@ -118,7 +114,6 @@ async function submit() {
 
 function resetForm() {
   selectedUpiId.value = undefined;
-  selectedConfigId.value = undefined;
   slug.value = "";
   baseUrl.value = "";
   gs1DataAttributes.value = {};
@@ -180,23 +175,6 @@ function cancel() {
             :placeholder="t('permalink.create.slug.placeholder')"
             :disabled="busy"
             autocomplete="off"
-          />
-        </div>
-
-        <div class="flex flex-col gap-2">
-          <label for="permalink-create-config" class="text-sm leading-6 font-medium text-gray-900">
-            {{ t("permalink.create.selectConfig") }}
-          </label>
-          <Select
-            id="permalink-create-config"
-            v-model="selectedConfigId"
-            data-testid="permalink-create-config-select"
-            :options="props.configs"
-            option-value="id"
-            :option-label="configLabel"
-            :placeholder="t('permalink.create.selectConfigPlaceholder')"
-            :disabled="busy"
-            show-clear
           />
         </div>
       </template>

--- a/apps/client/src/components/permalinks/PermalinkEditDialog.vue
+++ b/apps/client/src/components/permalinks/PermalinkEditDialog.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import type { PermalinkPublicDto, PresentationConfigurationDto } from "@open-dpp/dto";
+import type { PermalinkPublicDto } from "@open-dpp/dto";
 import { PermalinkKind } from "@open-dpp/dto";
 import { isAxiosError } from "axios";
 import { computed, ref, watch } from "vue";
@@ -26,8 +26,6 @@ const notificationStore = useNotificationStore();
 
 const slug = ref<string>("");
 const baseUrl = ref<string>("");
-const selectedConfigId = ref<string | undefined>(undefined);
-const configs = ref<PresentationConfigurationDto[]>([]);
 const gs1DataAttributes = ref<Record<string, string>>({});
 const gs1AttributesValid = ref(true);
 
@@ -51,32 +49,11 @@ watch(
   (pl) => {
     slug.value = pl.slug ?? "";
     baseUrl.value = pl.baseUrl ?? "";
-    selectedConfigId.value = pl.presentationConfigurationId ?? undefined;
     gs1DataAttributes.value = pl.gs1DataAttributes ?? {};
     slugError.value = null;
   },
   { immediate: true },
 );
-
-watch(
-  model,
-  async (visible) => {
-    if (!visible || isGs1Link.value || locked.value) return;
-    try {
-      const response = await apiClient.dpp.passports.presentationConfiguration.list(
-        props.permalink.passportId,
-      );
-      configs.value = response.data ?? [];
-    } catch (e) {
-      errorHandlingStore.logErrorWithNotification(t("permalink.edit.saveError"), e);
-    }
-  },
-  { immediate: true },
-);
-
-function configLabel(config: PresentationConfigurationDto): string {
-  return config.label ?? config.id;
-}
 
 function trimToNull(value: string): string | null {
   const trimmed = value.trim();
@@ -95,9 +72,9 @@ async function save() {
             Object.keys(gs1DataAttributes.value).length > 0 ? gs1DataAttributes.value : null,
         }
       : {
+          // ponytail: presentationConfigurationId omitted (#684) — backend preserves existing
           slug: trimToNull(slug.value),
           baseUrl: trimToNull(baseUrl.value),
-          presentationConfigurationId: selectedConfigId.value ?? null,
         };
 
     const result = await apiClient.dpp.permalinks.updateById(props.permalink.id, body);
@@ -161,23 +138,6 @@ function cancel() {
         <small v-if="slugError" data-testid="permalink-edit-slug-error" class="text-red-500">
           {{ slugError }}
         </small>
-      </div>
-
-      <div v-if="!isGs1Link" class="flex flex-col gap-2">
-        <label for="permalink-edit-config" class="text-sm leading-6 font-medium text-gray-900">
-          {{ t("permalink.edit.config.label") }}
-        </label>
-        <Select
-          id="permalink-edit-config"
-          v-model="selectedConfigId"
-          data-testid="permalink-edit-config-select"
-          :options="configs"
-          option-value="id"
-          :option-label="configLabel"
-          :placeholder="t('permalink.edit.config.placeholder')"
-          :disabled="locked || saving"
-          show-clear
-        />
       </div>
 
       <div class="flex flex-col gap-2">

--- a/apps/client/src/translations/de-DE.json
+++ b/apps/client/src/translations/de-DE.json
@@ -874,8 +874,6 @@
       "selectUpi": "Produktidentifikator (optional)",
       "selectUpiPlaceholder": "Kein Produktidentifikator — Pass direkt verlinken",
       "kindHint": "Erstellt einen {kind} Permalink.",
-      "selectConfig": "Präsentationskonfiguration (optional)",
-      "selectConfigPlaceholder": "Standardansicht",
       "loadFailed": "Die Formulardaten konnten nicht geladen werden. Bitte erneut versuchen.",
       "slug": {
         "label": "Kurzname (optional)",
@@ -897,10 +895,6 @@
         "label": "Typ",
         "presentation": "open-dpp",
         "gs1Link": "GS1 Digital Link"
-      },
-      "config": {
-        "label": "Präsentationskonfiguration",
-        "placeholder": "Standardansicht"
       },
       "saveSuccess": "Permalink gespeichert.",
       "saveError": "Permalink konnte nicht gespeichert werden.",

--- a/apps/client/src/translations/en-US.json
+++ b/apps/client/src/translations/en-US.json
@@ -874,8 +874,6 @@
       "selectUpi": "Product Identifier (optional)",
       "selectUpiPlaceholder": "No product identifier — link the passport directly",
       "kindHint": "Creates a {kind} permalink.",
-      "selectConfig": "Presentation configuration (optional)",
-      "selectConfigPlaceholder": "Standard view",
       "loadFailed": "The form data could not be loaded. Please try again.",
       "slug": {
         "label": "Short name (optional)",
@@ -897,10 +895,6 @@
         "label": "Type",
         "presentation": "open-dpp",
         "gs1Link": "GS1 Digital Link"
-      },
-      "config": {
-        "label": "Presentation configuration",
-        "placeholder": "Standard view"
       },
       "saveSuccess": "Permalink saved.",
       "saveError": "Could not save permalink.",


### PR DESCRIPTION
This pull request removes the ability to select a presentation configuration when creating or editing permalinks, since presentation configurations cannot currently be managed. The UI elements, related code, and translations for selecting presentation configurations have been removed or adjusted accordingly. When creating a permalink, the backend now auto-selects the most recently created configuration, and editing a permalink no longer modifies the configuration.

**Permalink creation and editing simplification:**

* Removed the select field and all related logic for choosing a presentation configuration in `PermalinkCreateDialog.vue` and `PermalinkEditDialog.vue`. The code now either auto-selects the last config on creation or leaves the configuration unchanged on edit. [[1]](diffhunk://#diff-4c87312a1173a003215bb46aa05ae7fa002ba1f389928b75576e452e4ae10d70L32) [[2]](diffhunk://#diff-4c87312a1173a003215bb46aa05ae7fa002ba1f389928b75576e452e4ae10d70L61-L64) [[3]](diffhunk://#diff-4c87312a1173a003215bb46aa05ae7fa002ba1f389928b75576e452e4ae10d70L96-R92) [[4]](diffhunk://#diff-4c87312a1173a003215bb46aa05ae7fa002ba1f389928b75576e452e4ae10d70L121) [[5]](diffhunk://#diff-4c87312a1173a003215bb46aa05ae7fa002ba1f389928b75576e452e4ae10d70L185-L201) [[6]](diffhunk://#diff-f26ee60d74d204e10e02d35c05890070fddd5327b84e364b29756f048d8df97fL2-R2) [[7]](diffhunk://#diff-f26ee60d74d204e10e02d35c05890070fddd5327b84e364b29756f048d8df97fL29-L30) [[8]](diffhunk://#diff-f26ee60d74d204e10e02d35c05890070fddd5327b84e364b29756f048d8df97fL54-L80) [[9]](diffhunk://#diff-f26ee60d74d204e10e02d35c05890070fddd5327b84e364b29756f048d8df97fR75-L100) [[10]](diffhunk://#diff-f26ee60d74d204e10e02d35c05890070fddd5327b84e364b29756f048d8df97fL166-L182)

**Translation cleanup:**

* Removed translation strings related to presentation configuration selection in both English and German translation files. [[1]](diffhunk://#diff-e562fe56091923f8f0b0cb1d0cd1ef1058e6ddefa77069c5db2d3e041ab4c776L877-L878) [[2]](diffhunk://#diff-e562fe56091923f8f0b0cb1d0cd1ef1058e6ddefa77069c5db2d3e041ab4c776L901-L904) [[3]](diffhunk://#diff-fa5da400a00f306be0ea0a711e9eb93a4ea865df8c706ad36a6a71d184c4c94eL877-L878) [[4]](diffhunk://#diff-fa5da400a00f306be0ea0a711e9eb93a4ea865df8c706ad36a6a71d184c4c94eL901-L904)

**Documentation update:**

* Updated the changeset to document the removal of the presentation configuration select field from permalinks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Simplified permalink creation and editing by removing presentation-configuration selection.
  * New permalinks automatically use the last available presentation configuration.
  * Existing permalink updates now retain the slug and base URL without changing presentation configuration.
  * Updated English and German translations to remove obsolete configuration-related labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->