### PR TITLE
fix(status): report the real application version instead of the Docker tag

### DIFF
--- a/.changeset/lucky-pandas-report.md
+++ b/.changeset/lucky-pandas-report.md
@@ -1,0 +1,5 @@
+---
+"@open-dpp/main": patch
+---
+
+Report the real application version again. CI passed the primary Docker tag as `APP_VERSION`, so images built from `main` reported the branch name — the UI rendered `vmain` instead of a version. The version is now derived from the package version (with `+sha.<short-sha>` on non-release builds), the backend falls back to the `package.json` bundled in the image when `APP_VERSION` is absent, and a non-semver `APP_VERSION` is ignored with a warning instead of being shown to users.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -179,6 +179,12 @@ jobs:
       # version, so derive the application version from the package instead.
       - name: Resolve application version
         id: app_version
+        # A ref name may contain shell metacharacters, so both values reach the
+        # script through the environment rather than through `${{ }}` expansion,
+        # which would splice a crafted tag name into this shell.
+        env:
+          REF_TYPE: ${{ github.ref_type }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
           set -euo pipefail
 
@@ -188,12 +194,13 @@ jobs:
             exit 1
           fi
 
-          if [ "${{ github.ref_type }}" = "tag" ]; then
+          if [ "$REF_TYPE" = "tag" ]; then
             # A release build: the tag it was dispatched for is authoritative.
-            version="${{ github.ref_name }}"
+            version="$REF_NAME"
             version="${version#v}"
             if [ "$version" != "$package_version" ]; then
-              echo "::warning::Tag ${{ github.ref_name }} does not match apps/main/package.json version $package_version; using $version"
+              printf '::warning::Tag %s does not match apps/main/package.json version %s; using %s\n' \
+                "$REF_NAME" "$package_version" "$version"
             fi
           else
             # Not a release: mark it with the commit so a :latest or PR image is
@@ -202,8 +209,8 @@ jobs:
             version="${package_version}+sha.${GITHUB_SHA:0:7}"
           fi
 
-          echo "value=$version" >> "$GITHUB_OUTPUT"
-          echo "Resolved APP_VERSION=$version"
+          printf 'value=%s\n' "$version" >> "$GITHUB_OUTPUT"
+          printf 'Resolved APP_VERSION=%s\n' "$version"
 
       - name: Build and push by digest
         id: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -173,6 +173,38 @@ jobs:
             type=semver,pattern={{version}}
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
 
+      # `steps.meta.outputs.version` is the primary *Docker tag*, which is the
+      # branch name on a `main` push and `sha-<short-sha>` on a pull request.
+      # Baking that into the image made the UI show "vmain" instead of a
+      # version, so derive the application version from the package instead.
+      - name: Resolve application version
+        id: app_version
+        run: |
+          set -euo pipefail
+
+          package_version=$(jq -r '.version' apps/main/package.json)
+          if [ -z "$package_version" ] || [ "$package_version" = "null" ]; then
+            echo "::error::Could not read .version from apps/main/package.json" >&2
+            exit 1
+          fi
+
+          if [ "${{ github.ref_type }}" = "tag" ]; then
+            # A release build: the tag it was dispatched for is authoritative.
+            version="${{ github.ref_name }}"
+            version="${version#v}"
+            if [ "$version" != "$package_version" ]; then
+              echo "::warning::Tag ${{ github.ref_name }} does not match apps/main/package.json version $package_version; using $version"
+            fi
+          else
+            # Not a release: mark it with the commit so a :latest or PR image is
+            # distinguishable from the released version. `+` starts semver build
+            # metadata, so this stays a valid semantic version.
+            version="${package_version}+sha.${GITHUB_SHA:0:7}"
+          fi
+
+          echo "value=$version" >> "$GITHUB_OUTPUT"
+          echo "Resolved APP_VERSION=$version"
+
       - name: Build and push by digest
         id: build
         uses: docker/build-push-action@v6
@@ -183,7 +215,7 @@ jobs:
           target: ${{ matrix.target }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            APP_VERSION=${{ steps.meta.outputs.version }}
+            APP_VERSION=${{ steps.app_version.outputs.value }}
           cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}${{ matrix.image_suffix }}:build-cache-${{ matrix.target }}-${{ env.PLATFORM_PAIR }}
           cache-to: type=registry,mode=max,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}${{ matrix.image_suffix }}:build-cache-${{ matrix.target }}-${{ env.PLATFORM_PAIR }}
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}${{ matrix.image_suffix }},push-by-digest=true,name-canonical=true,push=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,9 @@ RUN pnpm deploy --filter=@open-dpp/main --prod ./prod/main
 
 FROM node:25-slim AS production
 
-ARG APP_VERSION=unknown
+# Left empty on purpose: an unset APP_VERSION makes the backend fall back to the
+# version of the package.json copied in below, instead of pinning a placeholder.
+ARG APP_VERSION=""
 
 ENV NODE_ENV=production
 ENV APP_VERSION=${APP_VERSION}
@@ -37,6 +39,8 @@ ENV OPEN_DPP_BACKEND_MAIN=/app/dist/main.js
 ENV OPEN_DPP_FRONTEND_ROOT=/app/dist/client/dist
 
 COPY --chown=node:node --from=build /build/prod/main/dist /app/dist
+# Source of the reported application version when APP_VERSION is not passed in.
+COPY --chown=node:node --from=build /build/prod/main/package.json /app/package.json
 COPY --chown=node:node /apps/main/public /app/public
 COPY --chown=node:node --from=build /build/prod/main/node_modules /app/node_modules
 COPY --chown=node:node --from=build /build/apps/client/dist /app/dist/client/dist

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -168,7 +168,7 @@ The version the app shows in its UI (sign-in page and sidebar footer, served by 
 
 The `+sha.<short-sha>` suffix is semver build metadata, so a rolling `:latest` image is distinguishable from the released `:<version>` image that shares its commit.
 
-If `APP_VERSION` is not passed at build time, the backend falls back to the `package.json` bundled in the image, so a plain `docker build .` still reports the right version. `APP_VERSION` values that are not valid semantic versions — Docker tag names such as `main` or `sha-abc1234` — are ignored with a warning in the logs rather than shown to users.
+If `APP_VERSION` is not passed at build time, the backend falls back to the `package.json` bundled in the image, so a plain `docker build .` still reports the right version. `APP_VERSION` values that are not valid semantic versions — Docker tag names such as `main` or `sha-abc1234`, or a `v`-prefixed `v3.1.3` (the UI renders the `v` itself) — are ignored with a warning in the logs rather than shown to users.
 
 If you run the **manual / local release** escape hatch, remember to create the `v<version>` tag yourself after `pnpm release`:
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -157,6 +157,19 @@ To give each Changesets release a corresponding version-tagged Docker image (e.g
 | Docker `:<version>`                 | `build.yml` (dispatched at `v<version>` ref) | Pinnable Docker image for the release.                                                      |
 | Docker `:latest`, `:main`, `:sha-*` | `build.yml` (every push to main)             | Rolling tags; unchanged by this flow.                                                       |
 
+### The version reported by the running app
+
+The version the app shows in its UI (sign-in page and sidebar footer, served by `GET /api/status`) is **not** derived from the Docker tag. `build.yml` resolves it in its `Resolve application version` step and passes it to the image as the `APP_VERSION` build argument:
+
+| Build                   | `APP_VERSION`                                      |
+| ----------------------- | -------------------------------------------------- |
+| `v<version>` tag ref    | `<version>` (from the tag)                         |
+| push to `main`, or a PR | `<apps/main/package.json version>+sha.<short-sha>` |
+
+The `+sha.<short-sha>` suffix is semver build metadata, so a rolling `:latest` image is distinguishable from the released `:<version>` image that shares its commit.
+
+If `APP_VERSION` is not passed at build time, the backend falls back to the `package.json` bundled in the image, so a plain `docker build .` still reports the right version. `APP_VERSION` values that are not valid semantic versions — Docker tag names such as `main` or `sha-abc1234` — are ignored with a warning in the logs rather than shown to users.
+
 If you run the **manual / local release** escape hatch, remember to create the `v<version>` tag yourself after `pnpm release`:
 
 ```bash

--- a/apps/main/src/status/application/services/status.service.spec.ts
+++ b/apps/main/src/status/application/services/status.service.spec.ts
@@ -36,6 +36,14 @@ describe("StatusService", () => {
     expect(status.version).toBe("9.9.9-app-version");
   });
 
+  it("keeps build metadata in APP_VERSION", () => {
+    process.env.APP_VERSION = "3.1.3+sha.abc1234";
+
+    const status = service.getStatus();
+
+    expect(status.version).toBe("3.1.3+sha.abc1234");
+  });
+
   it("falls back to npm_package_version when APP_VERSION is not set", () => {
     delete process.env.APP_VERSION;
     process.env.npm_package_version = "7.7.7-npm-version";
@@ -45,12 +53,36 @@ describe("StatusService", () => {
     expect(status.version).toBe("7.7.7-npm-version");
   });
 
-  it("returns 'unknown' when neither env var is set", () => {
+  // Regression: CI passed the primary Docker tag as APP_VERSION, so images
+  // built from main reported "main" as the application version.
+  it.each(["main", "latest", "sha-abc1234", "unknown"])(
+    "ignores the non-semver APP_VERSION %p",
+    (appVersion) => {
+      process.env.APP_VERSION = appVersion;
+      process.env.npm_package_version = "7.7.7-npm-version";
+
+      const status = service.getStatus();
+
+      expect(status.version).toBe("7.7.7-npm-version");
+    },
+  );
+
+  it("ignores an empty APP_VERSION", () => {
+    process.env.APP_VERSION = "";
+    process.env.npm_package_version = "7.7.7-npm-version";
+
+    const status = service.getStatus();
+
+    expect(status.version).toBe("7.7.7-npm-version");
+  });
+
+  it("falls back to the bundled package version when no env var is set", () => {
     delete process.env.APP_VERSION;
     delete process.env.npm_package_version;
 
     const status = service.getStatus();
 
-    expect(status.version).toBe("unknown");
+    // Asserting the shape, not the value, so releases do not break this test.
+    expect(status.version).toMatch(/^\d+\.\d+\.\d+/);
   });
 });

--- a/apps/main/src/status/application/services/status.service.ts
+++ b/apps/main/src/status/application/services/status.service.ts
@@ -1,11 +1,40 @@
 import process from "node:process";
-import { Injectable } from "@nestjs/common";
+import { Injectable, Logger } from "@nestjs/common";
+import { isValidAppVersion, resolveAppVersion } from "../../domain/app-version";
 import { Status } from "../../domain/status";
+import { readBundledPackageVersion } from "../../infrastructure/package-json-version";
 
 @Injectable()
 export class StatusService {
+  private readonly logger = new Logger(StatusService.name);
+  private warnedAboutInvalidEnvVersion = false;
+
   getStatus(): Status {
-    const version = process.env.APP_VERSION ?? process.env.npm_package_version ?? "unknown";
+    const envVersion = process.env.APP_VERSION;
+    this.warnAboutInvalidEnvVersion(envVersion);
+
+    // The bundled package.json is the last resort so that an image built
+    // without an APP_VERSION build argument still reports its real version.
+    const version = resolveAppVersion([
+      envVersion,
+      process.env.npm_package_version,
+      readBundledPackageVersion(),
+    ]);
+
     return Status.create({ version });
+  }
+
+  private warnAboutInvalidEnvVersion(envVersion: string | undefined) {
+    if (this.warnedAboutInvalidEnvVersion) {
+      return;
+    }
+    if (!envVersion?.trim() || isValidAppVersion(envVersion)) {
+      return;
+    }
+    this.warnedAboutInvalidEnvVersion = true;
+    this.logger.warn(
+      `Ignoring APP_VERSION="${envVersion}" because it is not a semantic version. ` +
+        `Falling back to the version bundled with this build.`,
+    );
   }
 }

--- a/apps/main/src/status/domain/app-version.spec.ts
+++ b/apps/main/src/status/domain/app-version.spec.ts
@@ -16,6 +16,14 @@ describe("isValidAppVersion", () => {
     },
   );
 
+  // `semver.valid()` accepts these, but the UI adds its own "v" prefix.
+  it.each(["v1.2.3", "v3.1.3+sha.abc1234", " v0.1.0 "])(
+    "rejects the v-prefixed version %p",
+    (candidate) => {
+      expect(isValidAppVersion(candidate)).toBe(false);
+    },
+  );
+
   it("rejects undefined and null", () => {
     expect(isValidAppVersion(undefined)).toBe(false);
     expect(isValidAppVersion(null)).toBe(false);
@@ -33,6 +41,10 @@ describe("resolveAppVersion", () => {
 
   it("trims the resolved version", () => {
     expect(resolveAppVersion([" 3.1.3 "])).toBe("3.1.3");
+  });
+
+  it("skips a v-prefixed candidate", () => {
+    expect(resolveAppVersion(["v1.2.3", "3.1.3"])).toBe("3.1.3");
   });
 
   it("returns unknown when no candidate is a semantic version", () => {

--- a/apps/main/src/status/domain/app-version.spec.ts
+++ b/apps/main/src/status/domain/app-version.spec.ts
@@ -1,0 +1,45 @@
+import { UNKNOWN_APP_VERSION, isValidAppVersion, resolveAppVersion } from "./app-version";
+
+describe("isValidAppVersion", () => {
+  it.each(["1.2.3", "0.1.0", "3.1.3-rc.1", "3.1.3+sha.abc1234", " 3.1.3 "])(
+    "accepts the semantic version %p",
+    (candidate) => {
+      expect(isValidAppVersion(candidate)).toBe(true);
+    },
+  );
+
+  // The values Docker tags resolve to — these are what leaked into the UI.
+  it.each(["main", "latest", "sha-abc1234", "unknown", "v1.2.3-not-semver!", "", "  "])(
+    "rejects the non-version %p",
+    (candidate) => {
+      expect(isValidAppVersion(candidate)).toBe(false);
+    },
+  );
+
+  it("rejects undefined and null", () => {
+    expect(isValidAppVersion(undefined)).toBe(false);
+    expect(isValidAppVersion(null)).toBe(false);
+  });
+});
+
+describe("resolveAppVersion", () => {
+  it("returns the first candidate that is a semantic version", () => {
+    expect(resolveAppVersion([undefined, "main", "3.1.3", "9.9.9"])).toBe("3.1.3");
+  });
+
+  it("keeps build metadata intact", () => {
+    expect(resolveAppVersion(["3.1.3+sha.abc1234"])).toBe("3.1.3+sha.abc1234");
+  });
+
+  it("trims the resolved version", () => {
+    expect(resolveAppVersion([" 3.1.3 "])).toBe("3.1.3");
+  });
+
+  it("returns unknown when no candidate is a semantic version", () => {
+    expect(resolveAppVersion([undefined, null, "", "main"])).toBe(UNKNOWN_APP_VERSION);
+  });
+
+  it("returns unknown when there are no candidates", () => {
+    expect(resolveAppVersion([])).toBe(UNKNOWN_APP_VERSION);
+  });
+});

--- a/apps/main/src/status/domain/app-version.ts
+++ b/apps/main/src/status/domain/app-version.ts
@@ -1,0 +1,28 @@
+import semver from "semver";
+
+export const UNKNOWN_APP_VERSION = "unknown";
+
+/**
+ * Only a semantic version is trustworthy as an application version. Rejecting
+ * everything else keeps Docker tag names that CI or a deployment may inject —
+ * a branch (`main`), a moving tag (`latest`), a commit tag (`sha-abc1234`) —
+ * from being rendered to users as the application version.
+ */
+export function isValidAppVersion(candidate: string | null | undefined): boolean {
+  if (!candidate) {
+    return false;
+  }
+  // Predicate only: `semver.valid()` strips build metadata
+  // ("3.1.3+sha.abc1234" -> "3.1.3"), so its return value must never be used
+  // as the version itself.
+  return semver.valid(candidate.trim()) !== null;
+}
+
+/**
+ * Picks the first candidate that is a semantic version, in the caller's order
+ * of preference.
+ */
+export function resolveAppVersion(candidates: Array<string | null | undefined>): string {
+  const version = candidates.find((candidate) => isValidAppVersion(candidate));
+  return version ? version.trim() : UNKNOWN_APP_VERSION;
+}

--- a/apps/main/src/status/domain/app-version.ts
+++ b/apps/main/src/status/domain/app-version.ts
@@ -12,10 +12,17 @@ export function isValidAppVersion(candidate: string | null | undefined): boolean
   if (!candidate) {
     return false;
   }
+  const trimmed = candidate.trim();
+  // `semver.valid()` tolerates a leading "v" ("v1.2.3" -> "1.2.3"), but the
+  // prefix is not part of a semantic version and the UI renders one of its own,
+  // so accepting "v1.2.3" here would show up as "vv1.2.3".
+  if (trimmed.startsWith("v")) {
+    return false;
+  }
   // Predicate only: `semver.valid()` strips build metadata
   // ("3.1.3+sha.abc1234" -> "3.1.3"), so its return value must never be used
   // as the version itself.
-  return semver.valid(candidate.trim()) !== null;
+  return semver.valid(trimmed) !== null;
 }
 
 /**

--- a/apps/main/src/status/infrastructure/package-json-version.spec.ts
+++ b/apps/main/src/status/infrastructure/package-json-version.spec.ts
@@ -1,0 +1,49 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { findPackageVersion, readBundledPackageVersion } from "./package-json-version";
+
+describe("readBundledPackageVersion", () => {
+  it("reads the version of the package this code is bundled with", () => {
+    // Asserting the shape, not the value, so releases do not break this test.
+    expect(readBundledPackageVersion()).toMatch(/^\d+\.\d+\.\d+/);
+  });
+});
+
+describe("findPackageVersion", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "package-json-version-"));
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("walks up to the nearest package.json", () => {
+    writeFileSync(join(root, "package.json"), JSON.stringify({ version: "4.5.6" }));
+    const nested = join(root, "dist", "status", "infrastructure");
+    mkdirSync(nested, { recursive: true });
+
+    expect(findPackageVersion(nested)).toBe("4.5.6");
+  });
+
+  it("skips a package.json without a version", () => {
+    writeFileSync(join(root, "package.json"), JSON.stringify({ version: "4.5.6" }));
+    const nested = join(root, "nested");
+    mkdirSync(nested);
+    writeFileSync(join(nested, "package.json"), JSON.stringify({ name: "no-version" }));
+
+    expect(findPackageVersion(nested)).toBe("4.5.6");
+  });
+
+  it("skips a malformed package.json", () => {
+    writeFileSync(join(root, "package.json"), JSON.stringify({ version: "4.5.6" }));
+    const nested = join(root, "nested");
+    mkdirSync(nested);
+    writeFileSync(join(nested, "package.json"), "{ not json");
+
+    expect(findPackageVersion(nested)).toBe("4.5.6");
+  });
+});

--- a/apps/main/src/status/infrastructure/package-json-version.ts
+++ b/apps/main/src/status/infrastructure/package-json-version.ts
@@ -1,0 +1,64 @@
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import process from "node:process";
+
+/**
+ * Walks up from `startDir` and returns the `version` of the nearest
+ * `package.json` that declares one. A `package.json` without a version — such
+ * as the workspace root — is skipped rather than treated as a match.
+ */
+export function findPackageVersion(startDir: string): string | undefined {
+  let directory = startDir;
+  for (;;) {
+    const candidate = join(directory, "package.json");
+    if (existsSync(candidate)) {
+      try {
+        const parsed = JSON.parse(readFileSync(candidate, "utf8")) as { version?: unknown };
+        if (typeof parsed.version === "string" && parsed.version.length > 0) {
+          return parsed.version;
+        }
+      } catch {
+        // Unreadable or malformed package.json: keep walking up rather than
+        // failing — the version is non-critical information.
+      }
+    }
+    const parent = dirname(directory);
+    if (parent === directory) {
+      return undefined;
+    }
+    directory = parent;
+  }
+}
+
+/**
+ * Where to start looking, most precise first. `__dirname` covers the CommonJS
+ * build, but is undefined when Jest loads this module as ESM, so the entrypoint
+ * and the working directory serve as fallbacks.
+ */
+function startDirectories(): string[] {
+  const directories: string[] = [];
+  if (typeof __dirname !== "undefined") {
+    directories.push(__dirname);
+  }
+  const entrypoint = process.env.OPEN_DPP_BACKEND_MAIN;
+  if (entrypoint) {
+    directories.push(dirname(entrypoint));
+  }
+  directories.push(process.cwd());
+  return directories;
+}
+
+let cached: { version: string | undefined } | undefined;
+
+/**
+ * The version of the package this build was made from. Cached because it cannot
+ * change while the process is running.
+ */
+export function readBundledPackageVersion(): string | undefined {
+  cached ??= {
+    version: startDirectories()
+      .map((directory) => findPackageVersion(directory))
+      .find((version) => version !== undefined),
+  };
+  return cached.version;
+}


### PR DESCRIPTION
Fixes #680.

## Root cause

`build.yml` passed `steps.meta.outputs.version` as the `APP_VERSION` build argument. That output is `docker/metadata-action`'s primary **Docker tag**, not a product version — the branch name on a push to `main`, `sha-<short-sha>` on a PR. So `:latest` images shipped `APP_VERSION=main` and the UI rendered `vmain`. The `npm_package_version` fallback in `StatusService` is unreachable in the container because `docker/startup.sh` launches a bare `node`.

Regression window: `0585f054` read the version from `package.json` and was correct everywhere; `16fd6f35` replaced that with the env vars.

## Changes

- **`.github/workflows/build.yml`** — new `Resolve application version` step derives `APP_VERSION` from `apps/main/package.json`. A tag ref uses the tag (with a warning, not a failure, if it disagrees with the package); every other build appends `+sha.<short-sha>` semver build metadata so a rolling `:latest` stays distinguishable from the release sharing its commit. Docker tag names are untouched.
- **`Dockerfile`** — bundle `package.json` in the image and default `APP_VERSION` to empty, so a build with no build argument still reports its real version.
- **`StatusService`** — resolve `APP_VERSION` → `npm_package_version` → bundled `package.json`, and ignore a non-semver `APP_VERSION` with a one-time warning instead of showing it to users, so a recurrence shows up in the logs rather than in the UI.
- New `status/domain/app-version.ts` (semver validation + resolution, framework-free) and `status/infrastructure/package-json-version.ts` (walk-up `package.json` reader, memoised).
- `RELEASING.md` documents what the running app reports per build type.

## Verification

Unit tests for the module, plus an end-to-end check on a real production image built with podman and run against a single-node Mongo replica set:

| Case | `GET /api/status` |
| --- | --- |
| No build argument (the bug's case) | `{"version":"3.1.3"}` — previously `main` |
| `APP_VERSION=main` injected | `{"version":"3.1.3"}` + warning in the log |
| `--build-arg APP_VERSION=3.1.3+sha.deadbee` | `{"version":"3.1.3+sha.deadbee"}` |

`pnpm exec jest src/status` (34 tests), `oxlint` and `oxfmt --check .` all pass.

After merge, the `build-and-push` log should show `APP_VERSION=3.1.3+sha.<sha>` for the `main` run and `3.1.3` for the tag-dispatched release run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Application versions are now consistently embedded in Docker images and displayed by the application.
  - Release builds use the release version, while development builds include commit information.
  - The application can recover its bundled version when an explicit version is unavailable.
  - Invalid version values are safely ignored, with a warning shown.

- **Documentation**
  - Added guidance describing version behavior for releases, main-branch builds, pull requests, and invalid values.

- **Tests**
  - Expanded coverage for version validation, fallback behavior, and build metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->