### PR TITLE
Fix bulk import bug: ensure `passportId` is visible in the bulk import run overview for imported rows; refactor `BulkImportRunItem` to separate passport assignment from status updates and update related tests

### DIFF
--- a/.changeset/fancy-deer-exist.md
+++ b/.changeset/fancy-deer-exist.md
@@ -1,0 +1,5 @@
+---
+"@open-dpp/main": minor
+---
+
+Fix bug within bulk import. Show passport id in bulk import run overview also if the processed row could be imported.

--- a/apps/main/src/aas/presentation/environment.service.ts
+++ b/apps/main/src/aas/presentation/environment.service.ts
@@ -548,7 +548,9 @@ export class EnvironmentService {
     modificationRequests: Map<string, ValueModificationRequest>,
     userContext: UserContext,
   ) {
-    const submodels = (await this.submodelRepository.findByIds(environment.submodels)).values();
+    const submodels = [
+      ...(await this.submodelRepository.findByIds(environment.submodels)).values(),
+    ];
     const ability = await this.loadAbility(environment, userContext.subject, userContext.userId);
     for (const [submodelIdentifier, valueRepresentation] of modificationRequests) {
       const submodel = submodels.find(

--- a/apps/main/src/bulk-import/application/services/bulk-import-run.service.spec.ts
+++ b/apps/main/src/bulk-import/application/services/bulk-import-run.service.spec.ts
@@ -488,7 +488,8 @@ describe("BulkImportRunService", () => {
       inputData: { sku: "done", weightKg: 1 },
       externalId: "done",
     });
-    alreadyCreatedItem.markCreated("passport-already-done");
+    alreadyCreatedItem.assignPassport("passport-already-done");
+    alreadyCreatedItem.markCreated();
     // ...and one row that never got started.
     const pendingItem = BulkImportRunItem.create({
       runId: run.id,

--- a/apps/main/src/bulk-import/application/services/bulk-import-run.service.ts
+++ b/apps/main/src/bulk-import/application/services/bulk-import-run.service.ts
@@ -204,6 +204,8 @@ export class BulkImportRunService implements OnApplicationBootstrap {
       ? existingLink.passportId
       : await this.createPassportAndLink(run, config, idValue);
 
+    item.assignPassport(passportId);
+
     const valueRepresentations = await config.applyToRow(item.inputData);
     await this.passportService.digitalProductDocumentService.modifyValueOfMultipleSubmodels(
       run.id,
@@ -215,9 +217,9 @@ export class BulkImportRunService implements OnApplicationBootstrap {
     );
 
     if (existingLink) {
-      item.markUpdated(passportId);
+      item.markUpdated();
     } else {
-      item.markCreated(passportId);
+      item.markCreated();
     }
   }
 

--- a/apps/main/src/bulk-import/domain/bulk-import-run-item.spec.ts
+++ b/apps/main/src/bulk-import/domain/bulk-import-run-item.spec.ts
@@ -22,7 +22,8 @@ describe("BulkImportRunItem", () => {
   it("marks a newly created passport", () => {
     const item = buildItem();
     const passportId = randomUUID();
-    item.markCreated(passportId);
+    item.assignPassport(passportId);
+    item.markCreated();
     expect(item.status).toEqual(BulkImportRunItemStatusDto.Created);
     expect(item.passportId).toEqual(passportId);
   });
@@ -30,7 +31,9 @@ describe("BulkImportRunItem", () => {
   it("marks an updated passport", () => {
     const item = buildItem();
     const passportId = randomUUID();
-    item.markUpdated(passportId);
+    item.assignPassport(passportId);
+
+    item.markUpdated();
     expect(item.status).toEqual(BulkImportRunItemStatusDto.Updated);
     expect(item.passportId).toEqual(passportId);
   });
@@ -44,7 +47,9 @@ describe("BulkImportRunItem", () => {
 
   it("round-trips through toPlain/fromPlain", () => {
     const item = buildItem();
-    item.markCreated(randomUUID());
+    item.assignPassport(randomUUID());
+
+    item.markCreated();
     const restored = BulkImportRunItem.fromPlain(item.toPlain());
     expect(restored.toPlain()).toEqual(item.toPlain());
   });

--- a/apps/main/src/bulk-import/domain/bulk-import-run-item.ts
+++ b/apps/main/src/bulk-import/domain/bulk-import-run-item.ts
@@ -97,15 +97,17 @@ export class BulkImportRunItem implements IPersistable {
     return this._status === BulkImportRunItemStatusDto.Pending;
   }
 
-  markCreated(passportId: string): void {
-    this._status = BulkImportRunItemStatusDto.Created;
+  assignPassport(passportId: string): void {
     this._passportId = passportId;
+  }
+
+  markCreated(): void {
+    this._status = BulkImportRunItemStatusDto.Created;
     this._error = null;
   }
 
-  markUpdated(passportId: string): void {
+  markUpdated(): void {
     this._status = BulkImportRunItemStatusDto.Updated;
-    this._passportId = passportId;
     this._error = null;
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Passport IDs now appear in bulk-import run overviews when processed rows are successfully imported.
  * Improved bulk-import processing reliability for rows that create or update passports.
  * Fixed value updates across multiple submodels to ensure all relevant data is processed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->