### PR TITLE
docs: update setup script URLs in README and getting started guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ To get up and running quickly, start with the [Getting Started guide](https://do
 ## Try it locally
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/open-dpp/open-dpp/main/scripts/setup.sh | bash
+curl -fsSL https://install.open-dpp.de | bash
 ```
 
 This downloads the example deployment files, generates local secrets, and starts the full stack with Docker Compose. Then open <http://localhost:3000>.

--- a/docs/home/getting-started.md
+++ b/docs/home/getting-started.md
@@ -16,7 +16,7 @@ This guide describes a basic self-hosted setup of open-dpp.
 The setup script downloads the deployment files, generates a local auth secret, and starts the stack:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/open-dpp/open-dpp/main/scripts/setup.sh | bash
+curl -fsSL https://install.open-dpp.de | bash
 ```
 
 In a cloned repository, run `./scripts/setup.sh` instead.


### PR DESCRIPTION
This pull request updates the installation instructions to use a new, simplified setup script URL. The changes ensure users are directed to the new installation endpoint for a smoother setup experience.

**Documentation updates:**

* Updated the installation command in `README.md` to use `https://install.open-dpp.de` instead of the previous GitHub raw script URL.
* Updated the installation command in `docs/home/getting-started.md` to use the new setup script URL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the local setup instructions to use the hosted installer endpoint.
  - Applied the updated installation command in both the README and Getting Started guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->