### PR TITLE
chore: bump pnpm to 11.26.0 to fix Renovate rebase deadlock

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -71,5 +71,5 @@
     "vitest": "^4.1.8",
     "vue-tsc": "^3.3.4"
   },
-  "packageManager": "pnpm@11.11.0"
+  "packageManager": "pnpm@11.26.0"
 }

--- a/apps/e2e/package.json
+++ b/apps/e2e/package.json
@@ -18,5 +18,5 @@
     "uuid": "^13.0.2",
     "zod": "^4.4.3"
   },
-  "packageManager": "pnpm@11.11.0"
+  "packageManager": "pnpm@11.26.0"
 }

--- a/apps/main/package.json
+++ b/apps/main/package.json
@@ -116,5 +116,5 @@
     "tsconfig-paths": "^4.2.0",
     "typescript": "^5.9.3"
   },
-  "packageManager": "pnpm@11.11.0"
+  "packageManager": "pnpm@11.26.0"
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -16,5 +16,5 @@
   "devDependencies": {
     "vitepress": "2.0.0-alpha.16"
   },
-  "packageManager": "pnpm@11.11.0"
+  "packageManager": "pnpm@11.26.0"
 }

--- a/package.json
+++ b/package.json
@@ -41,5 +41,5 @@
     "turbo": "^2.9.18",
     "zod": "^4.3.6"
   },
-  "packageManager": "pnpm@11.11.0"
+  "packageManager": "pnpm@11.26.0"
 }

--- a/packages/dto/package.json
+++ b/packages/dto/package.json
@@ -51,5 +51,5 @@
     "jest": "^30.4.2",
     "typescript": "^5.9.3"
   },
-  "packageManager": "pnpm@11.11.0"
+  "packageManager": "pnpm@11.26.0"
 }

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -63,5 +63,5 @@
       ]
     }
   },
-  "packageManager": "pnpm@11.11.0"
+  "packageManager": "pnpm@11.26.0"
 }

--- a/packages/exception/package.json
+++ b/packages/exception/package.json
@@ -63,5 +63,5 @@
       ]
     }
   },
-  "packageManager": "pnpm@11.11.0"
+  "packageManager": "pnpm@11.26.0"
 }

--- a/packages/permission/package.json
+++ b/packages/permission/package.json
@@ -61,5 +61,5 @@
       ]
     }
   },
-  "packageManager": "pnpm@11.11.0"
+  "packageManager": "pnpm@11.26.0"
 }

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -76,5 +76,5 @@
       "node_modules/(?!.*(@open-dpp|uuid))"
     ]
   },
-  "packageManager": "pnpm@11.11.0"
+  "packageManager": "pnpm@11.26.0"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -25,6 +25,3 @@ allowBuilds:
   sharp: true
   unrs-resolver: true
   vue-demi: true
-minimumReleaseAgeExclude:
-  # Renovate security update: pnpm@11.11.0
-  - pnpm@11.11.0


### PR DESCRIPTION
## Summary

Renovate's rebases of the open security PRs (#804–#815) die with `Timed out` / `SIGTERM` in the Mend job log. The cause is not the runner: **pnpm 11.11.0 deadlocks in peer dependency resolution** ([pnpm/pnpm#12921](https://github.com/pnpm/pnpm/issues/12921), a regression in 11.11.0 only, fixed in [11.12.0](https://github.com/pnpm/pnpm/releases/tag/v11.12.0)). Renovate installs the pnpm pinned in `packageManager`, runs `pnpm install --lockfile-only …`, the process parks at 0 % CPU and never finishes, and Renovate kills it after its fixed 15‑minute `executionTimeout`. The whole job aborts there, so no PR gets rebased and the Dependency Dashboard has been stale since 2026‑09‑04.

Changes:
- `packageManager` → `pnpm@11.26.0` in every workspace `package.json` (root, docs, apps/*, packages/*). The workflows read the pin via `pnpm/action-setup`, and the Dockerfile's `pnpm@latest-11` switches to the pin at runtime, so nothing else changes.
- Removed the `pnpm@11.11.0` entry under `minimumReleaseAgeExclude` in `pnpm-workspace.yaml`; 11.26.0 (published 2026‑09‑06) passes the 24 h gate on its own.
- `pnpm-lock.yaml` is untouched: `pnpm install --lockfile-only` with 11.26.0 reuses it as is.

## Evidence

Renovate's exact command on the postcss bump, run locally against `main`:

| pnpm | metadata cache / store | outcome |
|---|---|---|
| 11.11.0 | warm / warm | exit 0 after 5 s, lockfile **not** written |
| 11.11.0 | cold / warm | exit 0 after 16 s, lockfile **not** written |
| 11.11.0 | warm / cold | hung, killed at 120 s |
| 11.11.0 | cold / cold | hung, killed at 120 s |
| 11.11.0 | cold / cold, `minimumReleaseAge: 0` | hung, killed at 120 s |
| 11.26.0 | cold / cold | done in 11 s, lockfile written |

None of the 11.11.0 runs ever reached pnpm's `resolution_done` stage. 11.15.1 additionally fixed the resolver retaining full registry documents in memory for the release‑age check ([11.15.1](https://github.com/pnpm/pnpm/releases/tag/v11.15.1)), which matters on Mend's 3 GB runner with 1 800 lockfile entries.

## Test plan

- [x] `pnpm install --lockfile-only` with 11.26.0 leaves `pnpm-lock.yaml` unchanged
- [x] `pnpm install --frozen-lockfile` passes with 11.26.0
- [ ] CI green (build / lint / tests run with the new pin via `pnpm/action-setup`)
- [ ] After merge: tick **"Click on this checkbox to rebase all open PRs at once"** on the Dependency Dashboard (#816) and confirm the security PRs get rebased instead of timing out

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KHLSZ4S1zZPeMkUVZfB8Zs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the project’s pinned package manager version to 11.26.0 across all applications and packages.
  - Removed the exception that allowed the previous package manager version to bypass the 24-hour release-age policy.
  - These updates standardize package management and ensure newly used versions follow the project’s release-age requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->